### PR TITLE
Add cidan extractor and interface

### DIFF
--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_session.py
@@ -28,7 +28,9 @@ def session_to_nwb(
 
     # Add suite2p Segmentation
     suite2p_path = folder_path / "suite2p"
-    source_data.update(dict(Suite2pSegmentation=dict(folder_path=suite2p_path,plane_segmentation_name="Suite2pPlaneSegmentation")))
+    source_data.update(
+        dict(Suite2pSegmentation=dict(folder_path=suite2p_path, plane_segmentation_name="Suite2pPlaneSegmentation"))
+    )
     conversion_options.update(dict(Suite2pSegmentation=dict(stub_test=stub_test)))
 
     # Add CIDAN Segmentation
@@ -36,6 +38,8 @@ def session_to_nwb(
     parameters_file_path = cidan_path / "parameters.json"
     roi_list_file_path = cidan_path / "roi_list.json"
     mat_file_path = cidan_path / "timetraces.mat"
+    plane_segmentation_name = "CIDANPlaneSegmentation"
+
     source_data.update(
         dict(
             CIDANSegmentation=dict(
@@ -43,11 +47,20 @@ def session_to_nwb(
                 roi_list_file_path=roi_list_file_path,
                 mat_file_path=mat_file_path,
                 sampling_frequency=15.0,
-                plane_segmentation_name="CIDANPlaneSegmentation",
+                plane_segmentation_name=plane_segmentation_name,
             )
         )
     )
-    conversion_options.update(dict(CIDANSegmentation=dict(stub_test=stub_test)))
+    conversion_options.update(
+        dict(
+            CIDANSegmentation=dict(
+                include_roi_acceptance=False,
+                plane_segmentation_name=plane_segmentation_name,
+                mask_type="pixel",
+                stub_test=stub_test,
+            )
+        )
+    )
 
     # Add ophys metadata
     ophys_metadata_path = Path(__file__).parent / "metadata" / "benisty_2024_ophys_metadata.yaml"

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_session.py
@@ -7,6 +7,27 @@ from higley_lab_to_nwb.benisty_2024 import Benisty2024NWBConverter
 import os
 
 
+def _get_sampling_frequency_and_image_size(folder_path: Union[str, Path]):
+    from roiextractors.extractors.tiffimagingextractors.scanimagetiff_utils import (
+        extract_extra_metadata,
+        parse_metadata,
+        _get_scanimage_reader,
+    )
+    from natsort import natsorted
+
+    file_paths = natsorted(Path(folder_path).glob("*.tif"))
+    file_path = file_paths[0]
+    image_metadata = extract_extra_metadata(file_path=file_path)
+    parsed_metadata = parse_metadata(metadata=image_metadata)
+    ScanImageTiffReader = _get_scanimage_reader()
+    with ScanImageTiffReader(str(file_path)) as io:
+        shape = io.shape()  # [frames, rows, columns]
+    if len(shape) == 3:
+        _num_frames, _num_rows, _num_columns = shape
+    image_size = [_num_rows, _num_columns]
+    return parsed_metadata["sampling_frequency"], image_size
+
+
 def session_to_nwb(
     folder_path: Union[str, Path], output_dir_path: Union[str, Path], session_id: str, stub_test: bool = False
 ):
@@ -40,13 +61,15 @@ def session_to_nwb(
     mat_file_path = cidan_path / "timetraces.mat"
     plane_segmentation_name = "CIDANPlaneSegmentation"
 
+    sampling_frequency, image_size = _get_sampling_frequency_and_image_size(folder_path=imaging_path)
     source_data.update(
         dict(
             CIDANSegmentation=dict(
                 parameters_file_path=parameters_file_path,
                 roi_list_file_path=roi_list_file_path,
                 mat_file_path=mat_file_path,
-                sampling_frequency=15.0,
+                sampling_frequency=sampling_frequency,
+                image_size=image_size,
                 plane_segmentation_name=plane_segmentation_name,
             )
         )
@@ -56,7 +79,6 @@ def session_to_nwb(
             CIDANSegmentation=dict(
                 include_roi_acceptance=False,
                 plane_segmentation_name=plane_segmentation_name,
-                mask_type="pixel",
                 stub_test=stub_test,
             )
         )

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_session.py
@@ -22,14 +22,32 @@ def session_to_nwb(
     conversion_options = dict()
 
     # Add 2p Imaging
-    imaging_path = folder_path / "tiff"    
-    source_data.update(dict(TwoPhotonImagingGreenChannel=dict(folder_path=str(imaging_path), file_pattern="*.tif")))
-    conversion_options.update(dict(TwoPhotonImagingGreenChannel=dict(stub_test=stub_test)))
+    imaging_path = folder_path / "tiff"
+    source_data.update(dict(TwoPhotonImaging=dict(folder_path=str(imaging_path), file_pattern="*.tif")))
+    conversion_options.update(dict(TwoPhotonImaging=dict(stub_test=stub_test)))
 
-    # Add Segmentation
+    # Add suite2p Segmentation
     suite2p_path = folder_path / "suite2p"
-    source_data.update(dict(SegmentationGreenChannel=dict(folder_path=suite2p_path)))
-    conversion_options.update(dict(SegmentationGreenChannel=dict(stub_test=stub_test)))
+    source_data.update(dict(Suite2pSegmentation=dict(folder_path=suite2p_path,plane_segmentation_name="Suite2pPlaneSegmentation")))
+    conversion_options.update(dict(Suite2pSegmentation=dict(stub_test=stub_test)))
+
+    # Add CIDAN Segmentation
+    cidan_path = folder_path / "CIDAN"
+    parameters_file_path = cidan_path / "parameters.json"
+    roi_list_file_path = cidan_path / "roi_list.json"
+    mat_file_path = cidan_path / "timetraces.mat"
+    source_data.update(
+        dict(
+            CIDANSegmentation=dict(
+                parameters_file_path=parameters_file_path,
+                roi_list_file_path=roi_list_file_path,
+                mat_file_path=mat_file_path,
+                sampling_frequency=15.0,
+                plane_segmentation_name="CIDANPlaneSegmentation",
+            )
+        )
+    )
+    conversion_options.update(dict(CIDANSegmentation=dict(stub_test=stub_test)))
 
     # Add ophys metadata
     ophys_metadata_path = Path(__file__).parent / "metadata" / "benisty_2024_ophys_metadata.yaml"

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
@@ -5,7 +5,7 @@ from neuroconv import NWBConverter
 from neuroconv.utils import DeepDict
 
 from neuroconv.datainterfaces import ScanImageMultiFileImagingInterface, Suite2pSegmentationInterface
-from .interfaces.benisty_2024_cidansegmentation_interface import Benisty2024CidanSegmentationInterface
+from .interfaces import Benisty2024CidanSegmentationInterface
 
 class Benisty2024NWBConverter(NWBConverter):
     """Primary conversion class."""

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
@@ -2,15 +2,18 @@
 
 from typing import Dict
 from neuroconv import NWBConverter
-from neuroconv.datainterfaces import ScanImageMultiFileImagingInterface, Suite2pSegmentationInterface
 from neuroconv.utils import DeepDict
+
+from neuroconv.datainterfaces import ScanImageMultiFileImagingInterface, Suite2pSegmentationInterface
+from .interfaces.benisty_2024_cidansegmentation_interface import Benisty2024CidanSegmentationInterface
 
 class Benisty2024NWBConverter(NWBConverter):
     """Primary conversion class."""
 
     data_interface_classes = dict(
-        TwoPhotonImagingGreenChannel=ScanImageMultiFileImagingInterface,
-        SegmentationGreenChannel=Suite2pSegmentationInterface,
+        TwoPhotonImaging=ScanImageMultiFileImagingInterface,
+        Suite2pSegmentation=Suite2pSegmentationInterface,
+        CIDANSegmentation=Benisty2024CidanSegmentationInterface,
     )
     def __init__(self, source_data: Dict[str, dict],ophys_metadata: Dict[str, dict],  verbose: bool = True):
         super().__init__(source_data, verbose)
@@ -18,8 +21,13 @@ class Benisty2024NWBConverter(NWBConverter):
 
     def get_metadata(self) -> DeepDict:
         metadata = super().get_metadata()
-        segmentation_metadata = self.data_interface_objects["SegmentationGreenChannel"].get_metadata()
-        for segmentation_metadata_ind in range(len(segmentation_metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"])):
+
+        suite2p_segmentation_metadata = self.data_interface_objects["Suite2pSegmentation"].get_metadata()
+        for segmentation_metadata_ind in range(len(suite2p_segmentation_metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"])):
+            metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][segmentation_metadata_ind]["imaging_plane"] = self.ophys_metadata["Ophys"]["ImagingPlane"][0]["name"]
+
+        cidan_segmentation_metadata = self.data_interface_objects["CIDANSegmentation"].get_metadata()
+        for segmentation_metadata_ind in range(len(cidan_segmentation_metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"])):
             metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][segmentation_metadata_ind]["imaging_plane"] = self.ophys_metadata["Ophys"]["ImagingPlane"][0]["name"]
         
         metadata["Ophys"]["Device"] = self.ophys_metadata["Ophys"]["Device"]

--- a/src/higley_lab_to_nwb/benisty_2024/extractors/__init__.py
+++ b/src/higley_lab_to_nwb/benisty_2024/extractors/__init__.py
@@ -1,0 +1,1 @@
+from .benisty_2024_cidansegmentation_extractor import Benisty2024CidanSegmentationExtractor

--- a/src/higley_lab_to_nwb/benisty_2024/extractors/benisty_2024_cidansegmentation_extractor.py
+++ b/src/higley_lab_to_nwb/benisty_2024/extractors/benisty_2024_cidansegmentation_extractor.py
@@ -1,9 +1,9 @@
-"""A segmentation extractor for Suite2p.
+"""A segmentation extractor for Higley Lab using CIDAN software.
 
 Classes
 -------
-Suite2pSegmentationExtractor
-    A segmentation extractor for Suite2p.
+Benisty2024CidanSegmentationExtractor
+    A segmentation extractor for Higley Lab using CIDAN software.
 """
 
 import scipy.io
@@ -18,10 +18,6 @@ class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
     """A segmentation extractor for CIDAN."""
 
     extractor_name = "Benisty2024CidanSegmentationExtractor"
-    installed = True  # check at class level if installed or not
-    is_writable = False
-    mode = "file"
-    installation_mesg = ""  # error message when not installed
 
     def __init__(
         self,
@@ -40,6 +36,8 @@ class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
             The path to the CIDAN roi_list .json file.
         mat_file_path: str or Path
             The path to the CIDAN df/f traces .mat file.
+        sampling_frequency: float
+            The sampling frequency for the df/f traces.    
         """
         self.parameters_file_path = parameters_file_path
         self.roi_list_file_path = roi_list_file_path
@@ -50,14 +48,6 @@ class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
 
         mat_contents = scipy.io.loadmat(self.mat_file_path)
         self._roi_response_denoised = np.array(mat_contents["deltafoverf"]).T
-
-        self._image_size = (512, 512)
-
-        self._image_masks = _image_mask_extractor(
-            self.get_roi_pixel_masks(),
-            self.get_roi_ids(),
-            self.get_image_size(),
-        )
 
         with open(self.parameters_file_path) as file:
             self.parameters_dict = json.load(file)
@@ -79,9 +69,6 @@ class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
         return [pixel_mask[i] for i in roi_idx_]
-
-    def get_image_size(self):
-        return self._image_size
 
     def get_accepted_list(self):
         return self.get_roi_ids()

--- a/src/higley_lab_to_nwb/benisty_2024/extractors/benisty_2024_cidansegmentation_extractor.py
+++ b/src/higley_lab_to_nwb/benisty_2024/extractors/benisty_2024_cidansegmentation_extractor.py
@@ -25,6 +25,7 @@ class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
         roi_list_file_path: FilePathType,
         mat_file_path: FilePathType,
         sampling_frequency: float,
+        image_size: list,
     ):
         """Create SegmentationExtractor object out of CIDAN data type.
 
@@ -37,7 +38,9 @@ class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
         mat_file_path: str or Path
             The path to the CIDAN df/f traces .mat file.
         sampling_frequency: float
-            The sampling frequency for the df/f traces.    
+            The sampling frequency for the df/f traces.
+        image_size: list
+            The frame dimension.    
         """
         self.parameters_file_path = parameters_file_path
         self.roi_list_file_path = roi_list_file_path
@@ -48,7 +51,14 @@ class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
 
         mat_contents = scipy.io.loadmat(self.mat_file_path)
         self._roi_response_denoised = np.array(mat_contents["deltafoverf"]).T
-
+        
+        self._image_size = image_size
+        self._image_masks = _image_mask_extractor(
+            self.get_roi_pixel_masks(),
+            self.get_roi_ids(),
+            self.get_image_size(),
+        )
+        
         with open(self.parameters_file_path) as file:
             self.parameters_dict = json.load(file)
             # keep only paramenters that describe the segmentation algorithm
@@ -79,3 +89,6 @@ class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
 
     def get_sampling_frequency(self) -> float:
         return self._sampling_frequency
+
+    def get_image_size(self):
+        return self._image_size

--- a/src/higley_lab_to_nwb/benisty_2024/interfaces/__init__.py
+++ b/src/higley_lab_to_nwb/benisty_2024/interfaces/__init__.py
@@ -1,0 +1,1 @@
+from .benisty_2024_cidansegmentation_interface import Benisty2024CidanSegmentationInterface

--- a/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_extractor.py
+++ b/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_extractor.py
@@ -59,6 +59,12 @@ class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
             self.get_image_size(),
         )
 
+        with open(self.parameters_file_path) as file:
+            self.parameters_dict = json.load(file)
+            # keep only paramenters that describe the segmentation algorithm
+            self.parameters_dict.pop("dataset_params")
+            self.parameters_dict.pop("global_params")
+
     def get_roi_pixel_masks(self, roi_ids=None):
         pixel_mask = []
         with open(self.roi_list_file_path) as file:

--- a/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_extractor.py
+++ b/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_extractor.py
@@ -1,0 +1,88 @@
+"""A segmentation extractor for Suite2p.
+
+Classes
+-------
+Suite2pSegmentationExtractor
+    A segmentation extractor for Suite2p.
+"""
+
+import scipy.io
+import json
+import numpy as np
+from neuroconv.utils import FilePathType
+from roiextractors.extraction_tools import _image_mask_extractor
+from roiextractors.segmentationextractor import SegmentationExtractor
+
+
+class Benisty2024CidanSegmentationExtractor(SegmentationExtractor):
+    """A segmentation extractor for CIDAN."""
+
+    extractor_name = "Benisty2024CidanSegmentationExtractor"
+    installed = True  # check at class level if installed or not
+    is_writable = False
+    mode = "file"
+    installation_mesg = ""  # error message when not installed
+
+    def __init__(
+        self,
+        parameters_file_path: FilePathType,
+        roi_list_file_path: FilePathType,
+        mat_file_path: FilePathType,
+        sampling_frequency: float,
+    ):
+        """Create SegmentationExtractor object out of CIDAN data type.
+
+        Parameters
+        ----------
+        parameters_file_path: str or Path
+            The path to the CIDAN parameter .json file.
+        roi_list_file_path: str or Path
+            The path to the CIDAN roi_list .json file.
+        mat_file_path: str or Path
+            The path to the CIDAN df/f traces .mat file.
+        """
+        self.parameters_file_path = parameters_file_path
+        self.roi_list_file_path = roi_list_file_path
+        self.mat_file_path = mat_file_path
+        super().__init__()
+
+        self._sampling_frequency = sampling_frequency
+
+        mat_contents = scipy.io.loadmat(self.mat_file_path)
+        self._roi_response_denoised = np.array(mat_contents["deltafoverf"]).T
+
+        self._image_size = (512, 512)
+
+        self._image_masks = _image_mask_extractor(
+            self.get_roi_pixel_masks(),
+            self.get_roi_ids(),
+            self.get_image_size(),
+        )
+
+    def get_roi_pixel_masks(self, roi_ids=None):
+        pixel_mask = []
+        with open(self.roi_list_file_path) as file:
+            roi_list = json.load(file)
+            for roi in roi_list:
+                pixel_mask.append(np.stack([[x, y, 1] for [x, y] in roi["coordinates"]]))
+
+        if roi_ids is None:
+            roi_idx_ = range(self.get_num_rois())
+        else:
+            roi_idx = [np.where(np.array(i) == self.get_roi_ids())[0] for i in roi_ids]
+            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
+            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
+        return [pixel_mask[i] for i in roi_idx_]
+
+    def get_image_size(self):
+        return self._image_size
+
+    def get_accepted_list(self):
+        return self.get_roi_ids()
+
+    def get_rejected_list(self):
+        roi_list = self.get_roi_ids()
+        return np.zeros((len(roi_list)))
+
+    def get_sampling_frequency(self) -> float:
+        return self._sampling_frequency

--- a/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
+++ b/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
@@ -10,6 +10,19 @@ from .benisty_2024_cidansegmentation_extractor import (
     Benisty2024CidanSegmentationExtractor,
 )
 
+def format_string_for_parameters_dict(dict_obj, indent=2):
+    def format_key_value(key, value, level):
+        indentation = ' ' * (level * indent)
+        if isinstance(value, dict):
+            formatted_value = format_dict(value, level + 1)
+            return f"{indentation}{key}:\n{formatted_value}"
+        else:
+            return f"{indentation}{key}: {value}\n"
+    
+    def format_dict(d, level):
+        return ''.join([format_key_value(k, v, level) for k, v in d.items()])
+    
+    return format_dict(dict_obj, 0)
 
 class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
     """Interface for Suite2p segmentation data."""
@@ -76,10 +89,18 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
         fluorescence_metadata_per_plane = metadata["Ophys"]["Fluorescence"].pop(default_plane_segmentation_name)
         # override the default name of the plane segmentation
         metadata["Ophys"]["Fluorescence"][self.plane_segmentation_name] = fluorescence_metadata_per_plane
-        trace_names = [property_name for property_name in fluorescence_metadata_per_plane.keys() if property_name != "name"]
+        trace_names = [
+            property_name for property_name in fluorescence_metadata_per_plane.keys() if property_name != "name"
+        ]
+        comments=format_string_for_parameters_dict(dict_obj=self.segmentation_extractor.parameters_dict)
         for trace_name in trace_names:
-            default_raw_traces_name = fluorescence_metadata_per_plane[trace_name]["name"].replace(default_plane_suffix, "")
-            fluorescence_metadata_per_plane[trace_name].update(name=default_raw_traces_name + new_plane_name_suffix)
+            default_raw_traces_name = fluorescence_metadata_per_plane[trace_name]["name"].replace(
+                default_plane_suffix, ""
+            )
+            fluorescence_metadata_per_plane[trace_name].update(
+                name=default_raw_traces_name + new_plane_name_suffix,
+                comments=comments,
+            )
 
         return metadata
 

--- a/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
+++ b/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from neuroconv.datainterfaces.ophys.basesegmentationextractorinterface import BaseSegmentationExtractorInterface
 from neuroconv.utils import DeepDict, FilePathType
 
-from .benisty_2024_cidansegmentation_extractor import (
+from ..extractors.benisty_2024_cidansegmentation_extractor import (
     Benisty2024CidanSegmentationExtractor,
 )
 
@@ -64,7 +64,7 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
             sampling_frequency=sampling_frequency,
         )
 
-       plane_segmentation_name = plane_segmentation_name or "PlaneSegmentation"
+        plane_segmentation_name = plane_segmentation_name or "PlaneSegmentation"
 
         self.plane_segmentation_name = plane_segmentation_name
         self.verbose = verbose
@@ -103,28 +103,3 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
 
         return metadata
 
-    def add_to_nwbfile(
-        self,
-        nwbfile: NWBFile,
-        metadata: Optional[dict] = None,
-        stub_test: bool = False,
-        stub_frames: int = 100,
-        include_roi_centroids: bool = True,
-        include_roi_acceptance: bool = False,
-        mask_type: Optional[str] = "image",  # Literal["image", "pixel", "voxel"]
-        plane_segmentation_name: Optional[str] = None,
-        iterator_options: Optional[dict] = None,
-        compression_options: Optional[dict] = None,
-    ):
-        super().add_to_nwbfile(
-            nwbfile=nwbfile,
-            metadata=metadata,
-            stub_test=stub_test,
-            stub_frames=stub_frames,
-            include_roi_centroids=include_roi_centroids,
-            include_roi_acceptance=include_roi_acceptance,
-            mask_type=mask_type,
-            plane_segmentation_name=self.plane_segmentation_name,
-            iterator_options=iterator_options,
-            compression_options=compression_options,
-        )

--- a/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
+++ b/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
@@ -1,0 +1,110 @@
+from typing import Optional
+from pynwb import NWBFile
+from copy import deepcopy
+
+
+from neuroconv.datainterfaces.ophys.basesegmentationextractorinterface import BaseSegmentationExtractorInterface
+from neuroconv.utils import DeepDict, FilePathType
+
+from .benisty_2024_cidansegmentation_extractor import (
+    Benisty2024CidanSegmentationExtractor,
+)
+
+
+class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
+    """Interface for Suite2p segmentation data."""
+
+    display_name = "CIDAN Segmentation"
+    associated_suffixes = (".json", ".mat")
+    info = "Interface for CIDAN segmentation."
+    Extractor = Benisty2024CidanSegmentationExtractor
+
+    def __init__(
+        self,
+        parameters_file_path: FilePathType,
+        roi_list_file_path: FilePathType,
+        mat_file_path: FilePathType,
+        sampling_frequency: float,
+        plane_segmentation_name: Optional[str] = None,
+        verbose: bool = True,
+    ):
+        """Create SegmentationExtractor object out of CIDAN data type.
+
+        Parameters
+        ----------
+        parameters_file_path: str or Path
+            The path to the CIDAN parameter .json file.
+        roi_list_file_path: str or Path
+            The path to the CIDAN roi_list .json file.
+        mat_file_path: str or Path
+            The path to the CIDAN df/f traces .mat file.
+        sampling_frequency: float
+            The sampling frequency of the fluorescence traces
+        plane_segmentation_name: str, optional
+            The name of the plane segmentation to be added.
+        """
+
+        super().__init__(
+            parameters_file_path=parameters_file_path,
+            roi_list_file_path=roi_list_file_path,
+            mat_file_path=mat_file_path,
+            sampling_frequency=sampling_frequency,
+        )
+
+        if plane_segmentation_name is None:
+            plane_segmentation_name = "PlaneSegmentation"
+
+        self.plane_segmentation_name = plane_segmentation_name
+        self.verbose = verbose
+
+    def get_metadata(self) -> DeepDict:
+        metadata = super().get_metadata()
+
+        # No need to update the metadata links for the default plane segmentation name
+        default_plane_segmentation_name = metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][0]["name"]
+        if self.plane_segmentation_name == default_plane_segmentation_name:
+            return metadata
+
+        plane_segmentation_metadata = metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][0]
+        default_plane_segmentation_name = plane_segmentation_metadata["name"]
+        default_plane_suffix = default_plane_segmentation_name.replace("PlaneSegmentation", "")
+        new_plane_name_suffix = self.plane_segmentation_name.replace("PlaneSegmentation", "")
+        plane_segmentation_metadata.update(
+            name=self.plane_segmentation_name,
+        )
+
+        fluorescence_metadata_per_plane = metadata["Ophys"]["Fluorescence"].pop(default_plane_segmentation_name)
+        # override the default name of the plane segmentation
+        metadata["Ophys"]["Fluorescence"][self.plane_segmentation_name] = fluorescence_metadata_per_plane
+        trace_names = [property_name for property_name in fluorescence_metadata_per_plane.keys() if property_name != "name"]
+        for trace_name in trace_names:
+            default_raw_traces_name = fluorescence_metadata_per_plane[trace_name]["name"].replace(default_plane_suffix, "")
+            fluorescence_metadata_per_plane[trace_name].update(name=default_raw_traces_name + new_plane_name_suffix)
+
+        return metadata
+
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: Optional[dict] = None,
+        stub_test: bool = False,
+        stub_frames: int = 100,
+        include_roi_centroids: bool = True,
+        include_roi_acceptance: bool = False,
+        mask_type: Optional[str] = "image",  # Literal["image", "pixel", "voxel"]
+        plane_segmentation_name: Optional[str] = None,
+        iterator_options: Optional[dict] = None,
+        compression_options: Optional[dict] = None,
+    ):
+        super().add_to_nwbfile(
+            nwbfile=nwbfile,
+            metadata=metadata,
+            stub_test=stub_test,
+            stub_frames=stub_frames,
+            include_roi_centroids=include_roi_centroids,
+            include_roi_acceptance=include_roi_acceptance,
+            mask_type=mask_type,
+            plane_segmentation_name=self.plane_segmentation_name,
+            iterator_options=iterator_options,
+            compression_options=compression_options,
+        )

--- a/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
+++ b/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
@@ -64,8 +64,7 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
             sampling_frequency=sampling_frequency,
         )
 
-        if plane_segmentation_name is None:
-            plane_segmentation_name = "PlaneSegmentation"
+       plane_segmentation_name = plane_segmentation_name or "PlaneSegmentation"
 
         self.plane_segmentation_name = plane_segmentation_name
         self.verbose = verbose

--- a/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
+++ b/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
@@ -10,19 +10,21 @@ from ..extractors.benisty_2024_cidansegmentation_extractor import (
     Benisty2024CidanSegmentationExtractor,
 )
 
+
 def format_string_for_parameters_dict(dict_obj, indent=2):
     def format_key_value(key, value, level):
-        indentation = ' ' * (level * indent)
+        indentation = " " * (level * indent)
         if isinstance(value, dict):
             formatted_value = format_dict(value, level + 1)
             return f"{indentation}{key}:\n{formatted_value}"
         else:
             return f"{indentation}{key}: {value}\n"
-    
+
     def format_dict(d, level):
-        return ''.join([format_key_value(k, v, level) for k, v in d.items()])
-    
+        return "".join([format_key_value(k, v, level) for k, v in d.items()])
+
     return format_dict(dict_obj, 0)
+
 
 class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
     """Interface for Suite2p segmentation data."""
@@ -38,6 +40,7 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
         roi_list_file_path: FilePathType,
         mat_file_path: FilePathType,
         sampling_frequency: float,
+        image_size: list,
         plane_segmentation_name: Optional[str] = None,
         verbose: bool = True,
     ):
@@ -53,6 +56,8 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
             The path to the CIDAN df/f traces .mat file.
         sampling_frequency: float
             The sampling frequency of the fluorescence traces
+        image_size: list
+            The frame dimension.
         plane_segmentation_name: str, optional
             The name of the plane segmentation to be added.
         """
@@ -62,6 +67,7 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
             roi_list_file_path=roi_list_file_path,
             mat_file_path=mat_file_path,
             sampling_frequency=sampling_frequency,
+            image_size=image_size,
         )
 
         plane_segmentation_name = plane_segmentation_name or "PlaneSegmentation"
@@ -91,7 +97,7 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
         trace_names = [
             property_name for property_name in fluorescence_metadata_per_plane.keys() if property_name != "name"
         ]
-        comments=format_string_for_parameters_dict(dict_obj=self.segmentation_extractor.parameters_dict)
+        comments = format_string_for_parameters_dict(dict_obj=self.segmentation_extractor.parameters_dict)
         for trace_name in trace_names:
             default_raw_traces_name = fluorescence_metadata_per_plane[trace_name]["name"].replace(
                 default_plane_suffix, ""
@@ -102,4 +108,3 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
             )
 
         return metadata
-

--- a/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
+++ b/src/higley_lab_to_nwb/benisty_2024/interfaces/benisty_2024_cidansegmentation_interface.py
@@ -99,11 +99,12 @@ class Benisty2024CidanSegmentationInterface(BaseSegmentationExtractorInterface):
         ]
         comments = format_string_for_parameters_dict(dict_obj=self.segmentation_extractor.parameters_dict)
         for trace_name in trace_names:
-            default_raw_traces_name = fluorescence_metadata_per_plane[trace_name]["name"].replace(
+            default_traces_name = fluorescence_metadata_per_plane[trace_name]["name"].replace(
                 default_plane_suffix, ""
             )
             fluorescence_metadata_per_plane[trace_name].update(
-                name=default_raw_traces_name + new_plane_name_suffix,
+                name=default_traces_name + new_plane_name_suffix,
+                description="Fluorescence traces extracted with CIDAN software",
                 comments=comments,
             )
 

--- a/src/higley_lab_to_nwb/benisty_2024/metadata/benisty_2024_ophys_metadata.yaml
+++ b/src/higley_lab_to_nwb/benisty_2024/metadata/benisty_2024_ophys_metadata.yaml
@@ -4,12 +4,12 @@ Ophys:
       description: MOM microscope (Sutter Instruments) coupled to a 16x, 0.8 NA objective (Nikon). Excitation was driven by a Titanium-Sapphire Laser (Mai-Tai eHP DeepSee, Spectra-Physics).
       manufacturer: Sutter Instruments
   TwoPhotonSeries:
-    - name: TwoPhotonSeriesGreenChannel
+    - name: TwoPhotonSeries
       description: Imaging data from Green channel recorded with 2p microscope. Images were acquired at 512x512 resolution at 30 Hz using a galvo-resonant scan system controlled by ScanImage software (Vidrio).
-      imaging_plane: ImagingPlaneGreenChannel
+      imaging_plane: ImagingPlane
       unit: n.a.
   ImagingPlane:
-    - name: ImagingPlaneGreenChannel
+    - name: ImagingPlane
       description: Imaging plane for the Green channel recorded with 2p microscope.
       excitation_lambda: 920.0  # in nm
       location: Whole Brain

--- a/src/higley_lab_to_nwb/benisty_2024/notes/benisty_2024_notes.md
+++ b/src/higley_lab_to_nwb/benisty_2024/notes/benisty_2024_notes.md
@@ -18,6 +18,98 @@ Dual imaging was carried out using a custom microscope combining a Zeiss Axiozoo
 ### Data structure:
 - **Each .tif is a trial of N frame of [512,512]**
 
+- **CIDAN output**
+    - parameters.json: file containing all the settings for the algorithm
+    ```json
+    {
+    "global_params": {},
+    "dataset_params": {
+        "dataset_folder_path": "/home/sschickl/Downloads/animal7",
+        "trials_loaded": ["file_00001_00001.tif"],
+        "trials_all": ["file_00001_00001.tif"],
+        "single_file_mode": true,
+        "original_folder_trial_split": ["file_00001_00001.tif"],
+        "slice_stack": false,
+        "slice_every": 3,
+        "slice_start": 0,
+        "crop_stack": true,
+        "crop_x": [20,490],
+        "crop_y": [20,490],
+        "trial_split": true,
+        "trial_length": 500,
+        "auto_crop": false
+    },
+    "filter_params": {
+        "median_filter": false,
+        "median_filter_size": 3,
+        "z_score": false,
+        "hist_eq": true,
+        "localSpatialDenoising": true,
+        "pca": false,
+        "pca_threshold": 0.97
+    },
+    "box_params": {
+        "total_num_time_steps": 4,
+        "total_num_spatial_boxes": 1,
+        "spatial_overlap": 40
+    },
+    "eigen_params": {
+        "eigen_vectors_already_generated": false,
+        "num_eig": 50,
+        "normalize_w_k": 32,
+        "metric": "l2",
+        "knn": 50,
+        "accuracy": 75,
+        "eigen_accuracy": 8,
+        "connections": 40
+    },
+    "roi_extraction_params": {
+        "elbow_threshold_method": true,
+        "elbow_threshold_value": 0.95,
+        "eigen_threshold_method": true,
+        "eigen_threshold_value": 0.5,
+        "num_eigen_vector_select": 1,
+        "merge_temporal_coef": 0.9,
+        "roi_size_min": 30,
+        "roi_size_max": 600,
+        "merge": true,
+        "num_rois": 150,
+        "fill_holes": true,
+        "refinement": true,
+        "max_iter": 100,
+        "roi_circ_threshold": 0,
+        "roi_eccentricity_limit": 0.8,
+        "local_max_method": false
+    },
+    "time_trace_params": {
+        "min_neuropil_pixels": 25
+    }
+    }
+    ```
+    - roi_list.json: file containing the pixel_mask for each roi
+    ```json
+    [
+        {
+            "id": 0,
+            "coordinates": [[286,276],[286,278],[287,274],...],
+        }
+        {
+            "id": 1,
+            "coordinates": [...],
+        }
+        {
+            "id": 2,
+            "coordinates": [...],
+        }
+        {
+            "id": 3,
+            "coordinates": [...],
+        }
+        ...
+    ]
+    ```
+    - timetraces.mat: file containing df/f traces (simple rois x frames matrix)
+
 ### Imaging metadata (from Benisty paper)
 - Custom miscroscope: see description in the methods
 - stimulation wavelengths for the three optical channel: Imaging was performed by strobing 575 nm (jRCaMP1b), 470 nm (ACh3.0) and 395 nm (control)


### PR DESCRIPTION
Stub nwb [here](https://catalystneuro-processing.s3.us-east-2.amazonaws.com/higley-lab-to-nwb/04072021_am2psi_05_spont.nwb)

Add extractor and interface for [CIDAN](https://github.com/Mishne-Lab/cidan) segmentation software (with customized output for HigleyLab).

**CIDAN output**

- [x] parameters.json: file containing all the settings for the algorithm
- [x] roi_list.json: file containing the pixel_mask for each roi
    ```json
    [
        {
            "id": 0,
            "coordinates": [[286,276],[286,278],[287,274],...],
        }
        {
            "id": 1,
            "coordinates": [...],
        }
        {
            "id": 2,
            "coordinates": [...],
        }
        {
            "id": 3,
            "coordinates": [...],
        }
        ...
    ]
    ```

- [x] timetraces.mat: file containing df/f traces (simple rois x frames matrix)