### PR TITLE
Add visual stimuli dual sessions

### DIFF
--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -55,6 +55,21 @@ def dual_imaging_session_to_nwb(
     )
     conversion_options.update(dict(Spike2Signals=dict(stub_test=stub_test)))
 
+    csv_file_paths = glob.glob(os.path.join(folder_path, f"{session_id}*.csv"))
+    if csv_file_paths:
+        csv_file_path = csv_file_paths[0]
+        mat_file_path = os.path.splitext(csv_file_path)[0] + '.mat'
+        source_data.update(
+            dict(
+                VisualStimulusInterface=dict(
+                    mat_file_path=mat_file_path,
+                    csv_file_path=csv_file_path,
+                    stream_id=stream_ids[stream_names == "diode"][0],
+                )
+            )
+        )
+        conversion_options.update(dict(VisualStimulusInterface=dict(stub_test=stub_test)))
+
     # Add 2p Imaging
     imaging_path = data_dir_path / f"{subject_id}_2p"
     file_pattern = f"{session_id.split('_')[0]}_2p_{session_id.split('_')[1]}*.tif"
@@ -144,7 +159,7 @@ if __name__ == "__main__":
     output_dir_path = root_path / "Higley-conversion_nwb/"
     stub_test = True
     subject_id = "dbvdual035"
-    session_id = "20201231_00001"
+    session_id = "20201231_00002"
     dual_imaging_session_to_nwb(
         data_dir_path=data_dir_path,
         output_dir_path=output_dir_path,

--- a/src/higley_lab_to_nwb/interfaces/spike2signals_interface.py
+++ b/src/higley_lab_to_nwb/interfaces/spike2signals_interface.py
@@ -128,13 +128,15 @@ class Spike2SignalsInterface(BaseDataInterface):
                 event_name=stream_name,
                 event_type_description=f"The onset times of the {stream_name} event.",
                 pulse_value=1,
+                check_ragged = False,
             )
             if len(timestamps):
                 for timestamp in timestamps[:end_frame]:
                     ttls_table.add_row(
                         ttl_type=ttl_type,
                         timestamp=timestamp,
-                    )
+                        check_ragged = False,
+                    )        
 
         nwbfile.add_acquisition(ttl_types_table)
         nwbfile.add_acquisition(ttls_table)

--- a/src/higley_lab_to_nwb/interfaces/visual_stimulus_interface.py
+++ b/src/higley_lab_to_nwb/interfaces/visual_stimulus_interface.py
@@ -167,6 +167,7 @@ class VisualStimulusInterface(BaseDataInterface):
                 spatial_frequency=spatial_frequencies[frame][0],
                 stimulus_size=sizes[frame][0],
                 screen_coordinates=screen_coordinates[frame][:],
+                check_ragged = False,
             )
 
         nwbfile.add_time_intervals(intervals_table)


### PR DESCRIPTION
#23 and #27 to be reviewed first
Add visual stimuli interface. The event times are here defined in a separate mat file not in the spike2 .smr output file.
I simply adapted the interface to work with both.

Stub file for a session with visual stimulus [here](https://catalystneuro-processing.s3.us-east-2.amazonaws.com/higley-lab-to-nwb/20201231_00002_dbvdual035.nwb)