### PR TITLE
Update Visual Stimulus Interface

### DIFF
--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_2p_only_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_2p_only_session.py
@@ -6,7 +6,7 @@ from neuroconv.utils import load_dict_from_file, dict_deep_update
 from higley_lab_to_nwb.benisty_2024 import Benisty2024NWBConverter
 from higley_lab_to_nwb.interfaces.spike2signals_interface import get_streams
 import os
-import glob
+
 
 def _get_sampling_frequency_and_image_size(folder_path: Union[str, Path]):
     from roiextractors.extractors.tiffimagingextractors.scanimagetiff_utils import (
@@ -28,6 +28,7 @@ def _get_sampling_frequency_and_image_size(folder_path: Union[str, Path]):
     image_size = [_num_rows, _num_columns]
     return parsed_metadata["sampling_frequency"], image_size
 
+
 def session_to_nwb(
     folder_path: Union[str, Path], output_dir_path: Union[str, Path], session_id: str, stub_test: bool = False
 ):
@@ -45,7 +46,7 @@ def session_to_nwb(
     search_pattern = "_".join(session_id.split("_")[:2])
 
     # Add Analog signals from Spike2
-    file_path = glob.glob(os.path.join(folder_path, f"{search_pattern}*.smrx"))[0]
+    file_path = list(folder_path.glob(f"{search_pattern}*.smrx"))[0]
     stream_ids, stream_names = get_streams(file_path=file_path)
 
     # Define each smrx signal name
@@ -69,7 +70,7 @@ def session_to_nwb(
     conversion_options.update(dict(Spike2Signals=dict(stub_test=stub_test)))
 
     if "vis_stim" in session_id:
-        csv_file_path = glob.glob(os.path.join(folder_path, f"{search_pattern}*.csv"))[0]
+        csv_file_path = list(folder_path.glob(f"{search_pattern}*.csv"))[0]
         source_data.update(
             dict(
                 VisualStimulusInterface=dict(
@@ -124,13 +125,13 @@ def session_to_nwb(
     )
 
     # Add Behavioral Video Recording
-    avi_files = glob.glob(os.path.join(folder_path, f"{search_pattern}*.avi"))
+    avi_files = list(folder_path.glob(f"{search_pattern}*.avi"))
     video_file_path = avi_files[0]
     source_data.update(dict(Video=dict(file_paths=[video_file_path], verbose=False)))
     conversion_options.update(dict(Video=dict(stub_test=stub_test)))
 
     # Add Facemap outpt
-    # mat_files = glob.glob(os.path.join(folder_path, f"{search_pattern}*_proc.mat"))
+    # mat_files = list(folder_path.glob(f"{search_pattern}*_proc.mat"))
     # mat_file_path = mat_files[0]
     # source_data.update(
     #     dict(

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -59,7 +59,7 @@ def dual_imaging_session_to_nwb(
     csv_file_paths = glob.glob(os.path.join(folder_path, f"{session_id}*.csv"))
     if csv_file_paths:
         csv_file_path = csv_file_paths[0]
-        mat_file_path = os.path.splitext(csv_file_path)[0] + ".mat"
+        mat_file_path = f"{csv_file_path.stem}.mat"
         start_times, stop_times = get_event_times_from_mat(file_path=mat_file_path, stream_name="diode")
         source_data.update(
             dict(

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -5,6 +5,7 @@ from typing import Union
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 from higley_lab_to_nwb.interfaces.spike2signals_interface import get_streams
 from higley_lab_to_nwb.benisty_2024 import Benisty2024NWBConverter
+from higley_lab_to_nwb.benisty_2024.utils import get_event_times_from_mat
 import os
 import glob
 
@@ -58,13 +59,14 @@ def dual_imaging_session_to_nwb(
     csv_file_paths = glob.glob(os.path.join(folder_path, f"{session_id}*.csv"))
     if csv_file_paths:
         csv_file_path = csv_file_paths[0]
-        mat_file_path = os.path.splitext(csv_file_path)[0] + '.mat'
+        mat_file_path = os.path.splitext(csv_file_path)[0] + ".mat"
+        start_times, stop_times = get_event_times_from_mat(file_path=mat_file_path, stream_name="diode")
         source_data.update(
             dict(
                 VisualStimulusInterface=dict(
-                    mat_file_path=mat_file_path,
                     csv_file_path=csv_file_path,
-                    stream_id=stream_ids[stream_names == "diode"][0],
+                    start_times=start_times,
+                    stop_times=stop_times,
                 )
             )
         )
@@ -101,11 +103,7 @@ def dual_imaging_session_to_nwb(
         )
     )
     conversion_options.update(
-        dict(
-            OnePhotonImaging=dict(
-                stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=0
-            )
-        )
+        dict(OnePhotonImaging=dict(stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=0))
     )
 
     channel_first_frame_index = 1
@@ -154,7 +152,7 @@ def dual_imaging_session_to_nwb(
 if __name__ == "__main__":
 
     # Parameters for conversion
-    root_path = Path("/media/amtra/Samsung_T5/CN_data")
+    root_path = Path("E:/CN_data")
     data_dir_path = root_path / "Higley-CN-data-share/Dual 2p Meso data"
     output_dir_path = root_path / "Higley-conversion_nwb/"
     stub_test = True

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -6,8 +6,6 @@ from neuroconv.utils import load_dict_from_file, dict_deep_update
 from higley_lab_to_nwb.interfaces.spike2signals_interface import get_streams
 from higley_lab_to_nwb.benisty_2024 import Benisty2024NWBConverter
 from higley_lab_to_nwb.benisty_2024.utils import get_event_times_from_mat
-import os
-import glob
 
 
 def dual_imaging_session_to_nwb(
@@ -30,7 +28,7 @@ def dual_imaging_session_to_nwb(
 
     # Add Analog signals from Spike2
     folder_path = data_dir_path / f"{subject_id}_1p"
-    file_path = glob.glob(os.path.join(folder_path, f"{session_id}*.smr"))[0]
+    file_path = list(folder_path.glob(f"{session_id}*.smr"))[0]
     stream_ids, stream_names = get_streams(file_path=file_path)
 
     # Define each smr signal name
@@ -56,11 +54,11 @@ def dual_imaging_session_to_nwb(
     )
     conversion_options.update(dict(Spike2Signals=dict(stub_test=stub_test)))
 
-    csv_file_paths = glob.glob(os.path.join(folder_path, f"{session_id}*.csv"))
+    csv_file_paths = list(folder_path.glob(f"{session_id}*.csv"))
     if csv_file_paths:
         csv_file_path = csv_file_paths[0]
-        mat_file_path = f"{csv_file_path.stem}.mat"
-        start_times, stop_times = get_event_times_from_mat(file_path=mat_file_path, stream_name="diode")
+        mat_file_path = folder_path / f"{csv_file_path.stem}.mat"
+        start_times, stop_times = get_event_times_from_mat(file_path=str(mat_file_path), stream_name="diode")
         source_data.update(
             dict(
                 VisualStimulusInterface=dict(

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_metadata.yaml
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_metadata.yaml
@@ -13,7 +13,7 @@ NWBFile:
   virus: 700nL of AAV1-cag-flex-gcamp6s-p2a-mruby2 into R V1
 Subject:
   species: Mus musculus
-  age: P1W2D # to be modified for each subject
+  age: P60D/P100D
   sex: F 
   strain: C57BL/6J
   genotype: VIP-cre;Camk2a-tTA;tetO-GCaMP6s (cre+/-)

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_metadata.yaml
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_metadata.yaml
@@ -1,12 +1,19 @@
 NWBFile:
-  session_description:
-    A rich text description of the experiment. Can also just be the abstract of the publication.
-  institution: Institution where the lab is located
+  related_publications:
+    - https://www.nature.com/articles/s41593-023-01498-y
+    - https://github.com/cardin-higley-lab/Benisty_Higley_2023
+  keywords: [Dual-color mesoscopic ACh, calcium imaging, visual stimulus, mouse]
+  experiment_description: Here, we used wide-field mesoscopic calcium imaging to monitor cortical dynamics in awake mice and developed an approach to quantify rapidly time-varying functional connectivity. We show that spontaneous behaviors are represented by fast changes in both the magnitude and correlational structure of cortical network activity. Combining mesoscopic imaging with simultaneous cellular-resolution two-photon microscopy demonstrated that correlations among neighboring neurons and between local and large-scale networks also encode behavior. Finally, the dynamic functional connectivity of mesoscale signals revealed subnetworks not predicted by traditional anatomical atlas-based parcellation of the cortex. These results provide new insights into how behavioral information is represented across the neocortex and demonstrate an analytical framework for investigating time-varying functional connectivity in neural networks.
+  session_description: All imaging was performed in awake, behaving mice that were head-fixed so that they could freely run on a cylindrical wheel. A magnetic angle sensor (Digikey) attached to the wheel continuously monitored wheel motion. Mice received at least three wheel-training habituation sessions before imaging to ensure consistent running bouts. During widefield imaging sessions, the face (including the pupil and whiskers) was illuminated with an IR LED bank and imaged with a miniature CMOS camera (Blackfly s-USB3, Flir) with a frame rate of 10 Hz using FlyCam2 software (Flir). Visual stimulation For visual stimulation experiments, sinusoidal drifting gratings (2 Hz, 0.04 cycles/degree) with varied contrast were generated using custom-written functions based on Psychtoolbox in Matlab and presented on an LCD monitor at a distance of 20 cm from the right eye. Stimuli were presented for 2 seconds with a 5 second inter-stimulus interval.
+  institution: Yale University School of Medicine
   lab: Higley
   experimenter:
-    - Last, First Middle
-    - Last, First Middle
+    - Moberly, Andrew # others
+  surgery: All surgical implant procedures were performed on adult mice (>P50). Mice were anesthetized using 1-2% isoflurane and maintained at 37°C for the duration of the surgery. For mesoscopic imaging, the skin and fascia above the skull were removed from the nasal bone to the posterior of the intraparietal bone and laterally between the temporal muscles. The surface of the skull was thoroughly cleaned with saline and the edges of the incision secured to the skull with Vetbond. A custom titanium headpost was secured to the skull with transparent dental cement (Metabond, Parkell), and a thin layer of dental cement was applied to the entire dorsal surface of the skull. Next, a layer of cyanoacrylate (Maxi-Cure, Bob Smith Industries) was used to cover the skull and left to cure ~30 min at room temperature to provide a smooth surface for transcranial imaging. A similar procedure was used to prepare mice for two-photon imaging, with the addition of a dual-layer glass window implanted into a small (~4 mm square) craniotomy placed over the left primary visual cortex. The edges of the window were then sealed to the skull with dental cement. For dual mesoscopic and two-photon imaging, a 2mm glass microprism (Tower Optical) was placed on top of a dual-layer glass window implanted over the right primary visual cortex.
+  virus: 700nL of AAV1-cag-flex-gcamp6s-p2a-mruby2 into R V1
 Subject:
-  species: Rattus norvegicus
-  age: P1W2D  # in ISO 8601, such as "P1W2D"
-  sex: U  # One of M, F, U, or O
+  species: Mus musculus
+  age: P1W2D # to be modified for each subject
+  sex: F 
+  strain: C57BL/6J
+  genotype: VIP-cre;Camk2a-tTA;tetO-GCaMP6s (cre+/-)

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
@@ -6,7 +6,6 @@ from neuroconv.utils import DeepDict
 
 from neuroconv.datainterfaces import ScanImageMultiFileImagingInterface, Suite2pSegmentationInterface
 from higley_lab_to_nwb.interfaces import (
-    Spike2SignalsInterface,
     VisualStimulusInterface,
     Spike2SignalsInterface,
     CidanSegmentationInterface,
@@ -61,7 +60,6 @@ class Benisty2024NWBConverter(NWBConverter):
         metadata["Ophys"]["ImagingPlane"] = self.ophys_metadata["Ophys"]["ImagingPlane"]
 
         return metadata
-
 
     def temporally_align_data_interfaces(self):
         ttlsignal_interface = self.data_interface_objects["Spike2Signals"]

--- a/src/higley_lab_to_nwb/benisty_2024/utils/__init__.py
+++ b/src/higley_lab_to_nwb/benisty_2024/utils/__init__.py
@@ -1,1 +1,4 @@
-from .lohani_2022_utils import read_session_start_time, get_tiff_file_paths_sorted_by_channel, create_tiff_stack
+from .benisty_2024_utils import (
+    get_event_times_from_mat,
+    get_event_times_from_spike2,
+)

--- a/src/higley_lab_to_nwb/benisty_2024/utils/benisty_2024_utils.py
+++ b/src/higley_lab_to_nwb/benisty_2024/utils/benisty_2024_utils.py
@@ -1,0 +1,52 @@
+import numpy as np
+from neuroconv.tools.signal_processing import get_rising_frames_from_ttl, get_falling_frames_from_ttl
+from spikeinterface.extractors import CedRecordingExtractor
+from neuroconv.tools import get_package
+
+
+def process_event_times(rising_times: np.ndarray, falling_times: np.ndarray):
+    # TODO define your custom function to processed event times extracted from Spike2 signal
+    return rising_times, falling_times
+
+
+def _test_sonpy_installation() -> None:
+    get_package(
+        package_name="sonpy",
+        excluded_python_versions=["3.10", "3.11"],
+        excluded_platforms_and_python_versions=dict(darwin=dict(arm=["3.8", "3.9", "3.10", "3.11"])),
+    )
+
+
+def get_event_times_from_spike2(file_path: str, stream_id: str, clean_event_times: bool = False):
+    _test_sonpy_installation()
+    extractor = CedRecordingExtractor(file_path=file_path, stream_id=stream_id)
+    times = extractor.get_times()
+    traces = extractor.get_traces()
+    rising_times = get_rising_frames_from_ttl(traces)
+    falling_times = get_falling_frames_from_ttl(traces)
+    if clean_event_times:
+        process_event_times(rising_times, falling_times)
+    start_times = times[rising_times]
+    stop_times = times[falling_times]
+    return start_times, stop_times
+
+
+def get_event_times_from_mat(file_path: str, stream_name: str = "diode"):
+    from pymatreader import read_mat
+
+    mat = read_mat(str(file_path))
+    # Check if the DATA group exists
+    if "DATA" in mat:
+        data_group = mat["DATA"]
+        # Check if the event_times dataset exists
+        if "event_times" in data_group and "channel_name" in data_group:
+            event_times = data_group["event_times"][data_group["channel_name"].index(stream_name)]
+            start_times = event_times[:, 0]
+            stop_times = event_times[:, 1]
+            return start_times, stop_times
+        elif "event_times" not in data_group:
+            raise f"event_times dataset does not exists in {file_path}"
+        elif "channel_name" not in data_group:
+            raise f"channel_names dataset does not exists in {file_path}"
+    else:
+        raise f"DATA group does not exists in {file_path}"

--- a/src/higley_lab_to_nwb/interfaces/visual_stimulus_interface.py
+++ b/src/higley_lab_to_nwb/interfaces/visual_stimulus_interface.py
@@ -1,123 +1,44 @@
-from typing import List, Literal
 import pandas as pd
-from neo import io
-
+import numpy as np
 from neuroconv import BaseDataInterface
-from neuroconv.tools import get_package
 from neuroconv.utils import FilePathType
-from neuroconv.tools.signal_processing import get_rising_frames_from_ttl, get_falling_frames_from_ttl
-from spikeinterface.extractors import CedRecordingExtractor
 from pynwb import NWBFile
 from pynwb.epoch import TimeIntervals
 
 
-def _test_sonpy_installation() -> None:
-    get_package(
-        package_name="sonpy",
-        excluded_python_versions=["3.10", "3.11"],
-        excluded_platforms_and_python_versions=dict(darwin=dict(arm=["3.8", "3.9", "3.10", "3.11"])),
-    )
-
-
-def get_streams(file_path: FilePathType) -> List[str]:
-    """Return a list of channel names as set in the recording extractor."""
-    r = io.CedIO(filename=file_path)
-    signal_channels = r.header["signal_channels"]
-    stream_ids = signal_channels["id"]
-    stream_names = signal_channels["name"]
-    return stream_ids, stream_names
-
-
 class VisualStimulusInterface(BaseDataInterface):
     """
-    Data interface class for converting Spike2 visual stimulus signals from CED (Cambridge Electronic
-    Design) using the :py:class:`~spikeinterface.extractors.CedRecordingExtractor`."""
+    Data interface class for converting visual stimulus signals from csv file, given start times and stop times of
+    each stimulus.
+    """
 
-    display_name = "Spike2 Recording"
-    associated_suffixes = (".smr", ".smrx")
-    info = "Interface for Spike2 analogue signals from CED (Cambridge Electronic Design)."
+    associated_suffixes = ".csv"
+    display_name = "Visual Stimulus"
 
     def __init__(
         self,
         csv_file_path: FilePathType,
-        stream_id: str,
-        spike2_file_path: FilePathType = None,
-        mat_file_path: FilePathType = None,
+        start_times: list,
+        stop_times: list,
         verbose: bool = True,
     ):
         """
          Parameters
         ----------
-        spike2_file_path : FilePathType
-            Path to .smr or .smrx file.
         csv_file_path : FilePathType
             Path to .csv file for visual stimulus characterization.
+        start_times : list
+            List of the visual stimulus start times in seconds.
+        stop_times : list
+            List of the visual stimulus stop times in seconds.
         verbose : bool, default: True
         """
-        _test_sonpy_installation()
-
-        if spike2_file_path is None and mat_file_path is None:
-            raise ValueError(
-                "Define either spike2_file_path or mat_file_path to extract the visual stimulus event times."
-            )
-
-        elif spike2_file_path is not None and mat_file_path is not None:
-            raise ValueError(
-                "Both spike2_file_path and mat_file_path have been defined. Define either spike2_file_path or mat_file_path to extract the visual stimulus event times."
-            )
-
-        elif spike2_file_path is not None:
-            super().__init__(
-                spike2_file_path=spike2_file_path,
-                csv_file_path=csv_file_path,
-                stream_id=stream_id,
-                verbose=verbose,
-            )
-            self._event_times_from_ttl = True
-
-        elif mat_file_path is not None:
-            super().__init__(
-                mat_file_path=mat_file_path,
-                csv_file_path=csv_file_path,
-                stream_id=stream_id,
-                verbose=verbose,
-            )
-            self._event_times_from_ttl = False
-
-    def get_event_times_from_ttl(self, rising: bool = True):
-        extractor = CedRecordingExtractor(
-            file_path=str(self.source_data["spike2_file_path"]), stream_id=self.source_data["stream_id"]
+        super().__init__(
+            csv_file_path=csv_file_path,
+            start_times=start_times,
+            stop_times=stop_times,
+            verbose=verbose,
         )
-        times = extractor.get_times()
-        traces = extractor.get_traces()
-        if rising:
-            event_times = get_rising_frames_from_ttl(traces)
-        else:
-            event_times = get_falling_frames_from_ttl(traces)
-
-        return times[event_times]
-
-    def get_event_times_from_table(self, event_type: Literal["start", "stop"]):
-        import h5py
-
-        with h5py.File(self.source_data["mat_file_path"], "r") as file:
-            # Check if the DATA group exists
-            if "DATA" in file:
-                data_group = file["DATA"]
-                # Check if the event_times dataset exists
-                if "event_times" in data_group:
-                    event_times_data = data_group["event_times"]
-                    event_time_ref = event_times_data[int(self.source_data["stream_id"]), 0]  # Assuming (8, 1) shape
-                    event_time_dataset = file[event_time_ref]
-                    times = event_time_dataset[:]
-                    if event_type == "start":
-                        return times[0]
-                    if event_type == "stop":
-                        return times[1]
-                else:
-                    raise f"event_times dataset does not exists in {self.source_data['mat_file_path']}"
-            else:
-                raise f"DATA group does not exists in {self.source_data['mat_file_path']}"
 
     def get_stimulus_feature(self, column_index):
         feature = pd.read_csv(self.source_data["csv_file_path"], usecols=column_index)
@@ -146,7 +67,8 @@ class VisualStimulusInterface(BaseDataInterface):
         sizes = self.get_stimulus_feature(column_index=[4])
         intervals_table.add_column(
             name="screen_coordinates",
-            description="Screen coordinates that define the position of the stimulus on the monitor, i.e. [x1,y1,x2,y2]."
+            description="Screen coordinates that define the position of the stimulus on the monitor, i.e. [x1,y1,x2,"
+            "y2]."
             "Left (x1): The x-coordinate of the left edge of the rectangle."
             "Top (y1): The y-coordinate of the top edge of the rectangle."
             "Right (x2): The x-coordinate of the right edge of the rectangle."
@@ -154,12 +76,8 @@ class VisualStimulusInterface(BaseDataInterface):
         )
         screen_coordinates = self.get_stimulus_feature(column_index=[5, 6, 7, 8])
 
-        if self._event_times_from_ttl:
-            start_times = self.get_event_times_from_ttl()
-            stop_times = self.get_event_times_from_ttl(rising=False)
-        else:
-            start_times = self.get_event_times_from_table(event_type="start")
-            stop_times = self.get_event_times_from_table(event_type="stop")
+        start_times = self.source_data["start_times"]
+        stop_times = self.source_data["stop_times"]
 
         n_frames = 100 if stub_test else len(start_times)
 

--- a/src/higley_lab_to_nwb/interfaces/visual_stimulus_interface.py
+++ b/src/higley_lab_to_nwb/interfaces/visual_stimulus_interface.py
@@ -144,7 +144,6 @@ class VisualStimulusInterface(BaseDataInterface):
         spatial_frequencies = self.get_stimulus_feature(column_index=[3])
         intervals_table.add_column(name="stimulus_size", description="Size of the visual stimulus, in degrees.")
         sizes = self.get_stimulus_feature(column_index=[4])
-        # TODO add a more descriptive text as description for "screen_coordinates" column
         intervals_table.add_column(
             name="screen_coordinates",
             description="Screen coordinates that define the position of the stimulus on the monitor, i.e. [x1,y1,x2,y2]."

--- a/src/higley_lab_to_nwb/interfaces/visual_stimulus_interface.py
+++ b/src/higley_lab_to_nwb/interfaces/visual_stimulus_interface.py
@@ -81,7 +81,7 @@ class VisualStimulusInterface(BaseDataInterface):
 
         n_frames = 100 if stub_test else len(start_times)
 
-        for frame in range(n_frames):
+        for frame in range(n_frames - 1):
             intervals_table.add_row(
                 start_time=start_times[frame],
                 stop_time=stop_times[frame],

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
@@ -71,9 +71,9 @@ def session_to_nwb(
     sampling_frequency = 10.0
     photon_series_index = 0
 
-    # Define a dictonary that for each excitation type associate the starting frame index
+    # Define a dictionary that for each excitation type associate the starting frame index
     excitation_type_to_start_frame_index_mapping = dict(Blue=0, Violet=1, Green=2)
-    # Define a dictonary that for each optical channel/filter associate the frame side
+    # Define a dictionary that for each optical channel/filter associate the frame side
     channel_to_frame_side_mapping = dict(Green="right", Red="left")
     # Define the excitation-channel combinations
     excitation_type_channel_comb = dict(Blue="Green", Violet="Green", Green="Red")
@@ -111,7 +111,7 @@ def session_to_nwb(
     source_data.update(dict(Video=dict(file_paths=[video_file_path], verbose=False)))
     conversion_options.update(dict(Video=dict(stub_test=stub_test)))
 
-    # Add Facemap outpt
+    # Add Facemap output
     mat_files = glob.glob(os.path.join(folder_path, f"{search_pattern}*_proc.mat"))
     mat_file_path = mat_files[0]
     source_data.update(
@@ -126,7 +126,7 @@ def session_to_nwb(
     converter = Lohani2022NWBConverter(
         source_data=source_data,
         excitation_type_channel_comb=excitation_type_channel_comb,
-        ophys_metadata = ophys_metadata,
+        ophys_metadata=ophys_metadata,
     )
 
     # Add datetime to conversion
@@ -151,11 +151,10 @@ def session_to_nwb(
 if __name__ == "__main__":
 
     # Parameters for conversion
-    root_path = Path("/media/amtra/Samsung_T5/CN_data")
+    root_path = Path("E:\CN_data")
     data_dir_path = root_path / "Higley-CN-data-share"
-    output_dir_path = root_path / "Higley-conversion_nwb/"
+    output_dir_path = root_path / "Higley-conversion_nwb"
     stub_test = True
-    session_ids = os.listdir(data_dir_path)
     session_id = "11222019_grabAM06_vis_stim"
     folder_path = data_dir_path / Path(session_id)
     session_to_nwb(

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
@@ -30,7 +30,7 @@ def session_to_nwb(
     search_pattern = "_".join(session_id.split("_")[:2])
 
     # Add Analog signals from Spike2
-    file_path = glob.glob(os.path.join(folder_path, f"{search_pattern}*.smrx"))[0]
+    file_path = list(folder_path.glob(f"{search_pattern}*.smrx"))[0]
     stream_ids, stream_names = get_streams(file_path=file_path)
 
     # Define each smrx signal name
@@ -49,7 +49,7 @@ def session_to_nwb(
     source_data.update(
         dict(
             Spike2Signals=dict(
-                file_path=file_path,
+                file_path=str(file_path),
                 ttl_stream_ids_to_names_map=TTLsignals_name_map,
                 behavioral_stream_ids_to_names_map=behavioral_name_map,
             )
@@ -58,7 +58,7 @@ def session_to_nwb(
     conversion_options.update(dict(Spike2Signals=dict(stub_test=stub_test)))
 
     if "vis_stim" in session_id:
-        csv_file_path = glob.glob(os.path.join(folder_path, f"{search_pattern}*.csv"))[0]
+        csv_file_path = list(folder_path.glob(f"{search_pattern}*.csv"))[0]
         mat_file_path = parcellation_folder_path / "smrx_signals.mat"
         start_times, stop_times = get_event_times_from_mat(file_path=str(mat_file_path))
         source_data.update(
@@ -111,13 +111,13 @@ def session_to_nwb(
         photon_series_index += 1
 
     # Add Behavioral Video Recording
-    avi_files = glob.glob(os.path.join(folder_path, f"{search_pattern}*.avi"))
+    avi_files = list(folder_path.glob(f"{search_pattern}*.avi"))
     video_file_path = avi_files[0]
     source_data.update(dict(Video=dict(file_paths=[video_file_path], verbose=False)))
     conversion_options.update(dict(Video=dict(stub_test=stub_test)))
 
     # Add Facemap output
-    mat_files = glob.glob(os.path.join(folder_path, f"{search_pattern}*_proc.mat"))
+    mat_files = list(folder_path.glob(f"{search_pattern}*_proc.mat"))
     mat_file_path = mat_files[0]
     source_data.update(
         dict(

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
@@ -75,34 +75,35 @@ def session_to_nwb(
     excitation_type_to_start_frame_index_mapping = dict(Blue=0, Violet=1, Green=2)
     # Define a dictonary that for each optical channel/filter associate the frame side
     channel_to_frame_side_mapping = dict(Green="right", Red="left")
+    # Define the excitation-channel combinations
+    excitation_type_channel_comb = dict(Blue="Green", Violet="Green", Green="Red")
 
-    for excitation_type in excitation_type_to_start_frame_index_mapping:
-        for channel in channel_to_frame_side_mapping:
-            start_frame_index = excitation_type_to_start_frame_index_mapping[excitation_type]
-            frame_side = channel_to_frame_side_mapping[channel]
-            tif_file_path = str(folder_path) + f"/{session_id}_channel{start_frame_index}_{frame_side}.tiff"
-            if not os.path.exists(tif_file_path):
-                create_tiff_stack(
-                    folder_path=folder_path,
-                    output_file_path=tif_file_path,
-                    start_frame_index=start_frame_index,
-                    frame_side=frame_side,
-                    stub_test=stub_test,
-                )
+    for excitation_type, channel in excitation_type_channel_comb.items():
+        start_frame_index = excitation_type_to_start_frame_index_mapping[excitation_type]
+        frame_side = channel_to_frame_side_mapping[channel]
+        tif_file_path = str(folder_path) + f"/{session_id}_channel{start_frame_index}_{frame_side}.tiff"
+        if not os.path.exists(tif_file_path):
+            create_tiff_stack(
+                folder_path=folder_path,
+                output_file_path=tif_file_path,
+                start_frame_index=start_frame_index,
+                frame_side=frame_side,
+                stub_test=stub_test,
+            )
 
-            suffix = f"{excitation_type}Excitation{channel}Channel"
-            interface_name = f"Imaging{suffix}"
-            source_data[interface_name] = {
-                "file_path": tif_file_path,
-                "sampling_frequency": sampling_frequency,
-                "photon_series_type": "OnePhotonSeries",
-            }
-            conversion_options[interface_name] = {
-                "stub_test": stub_test,
-                "photon_series_index": photon_series_index,
-                "photon_series_type": "OnePhotonSeries",
-            }
-            photon_series_index += 1
+        suffix = f"{excitation_type}Excitation{channel}Channel"
+        interface_name = f"Imaging{suffix}"
+        source_data[interface_name] = {
+            "file_path": tif_file_path,
+            "sampling_frequency": sampling_frequency,
+            "photon_series_type": "OnePhotonSeries",
+        }
+        conversion_options[interface_name] = {
+            "stub_test": stub_test,
+            "photon_series_index": photon_series_index,
+            "photon_series_type": "OnePhotonSeries",
+        }
+        photon_series_index += 1
 
     # Add Behavioral Video Recording
     avi_files = glob.glob(os.path.join(folder_path, f"{search_pattern}*.avi"))
@@ -124,8 +125,7 @@ def session_to_nwb(
 
     converter = Lohani2022NWBConverter(
         source_data=source_data,
-        excitation_types=excitation_type_to_start_frame_index_mapping.keys(),
-        channels=channel_to_frame_side_mapping.keys(),
+        excitation_type_channel_comb=excitation_type_channel_comb,
         ophys_metadata = ophys_metadata,
     )
 
@@ -156,7 +156,7 @@ if __name__ == "__main__":
     output_dir_path = root_path / "Higley-conversion_nwb/"
     stub_test = True
     session_ids = os.listdir(data_dir_path)
-    session_id = "11222019_grabAM06_spont"
+    session_id = "11222019_grabAM06_vis_stim"
     folder_path = data_dir_path / Path(session_id)
     session_to_nwb(
         folder_path=folder_path,

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
@@ -1,19 +1,22 @@
 """Primary script to run to convert an entire session for of data using the NWBConverter."""
 
 from pathlib import Path
-from typing import Union
+from typing import Union, Dict, Any
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 from higley_lab_to_nwb.lohani_2022 import Lohani2022NWBConverter
 from higley_lab_to_nwb.interfaces.spike2signals_interface import get_streams
-from higley_lab_to_nwb.lohani_2022.utils.lohani_2022_utils import create_tiff_stack, read_session_start_time
+from higley_lab_to_nwb.lohani_2022.utils import create_tiff_stack, read_session_start_time, get_event_times_from_mat
 import os
 import glob
 
 
 def session_to_nwb(
-    folder_path: Union[str, Path], output_dir_path: Union[str, Path], session_id: str, stub_test: bool = False
+    folder_path: Union[str, Path],
+    parcellation_folder_path: Union[str, Path],
+    output_dir_path: Union[str, Path],
+    session_id: str,
+    stub_test: bool = False,
 ):
-
     output_dir_path = Path(output_dir_path)
     if stub_test:
         output_dir_path = output_dir_path / "nwb_stub"
@@ -56,12 +59,14 @@ def session_to_nwb(
 
     if "vis_stim" in session_id:
         csv_file_path = glob.glob(os.path.join(folder_path, f"{search_pattern}*.csv"))[0]
+        mat_file_path = parcellation_folder_path / "smrx_signals.mat"
+        start_times, stop_times = get_event_times_from_mat(file_path=str(mat_file_path))
         source_data.update(
             dict(
                 VisualStimulusInterface=dict(
-                    spike2_file_path=file_path,
                     csv_file_path=csv_file_path,
-                    stream_id=stream_ids[stream_names == "Vis"][0],
+                    start_times=start_times,
+                    stop_times=stop_times,
                 )
             )
         )
@@ -149,16 +154,21 @@ def session_to_nwb(
 
 
 if __name__ == "__main__":
-
     # Parameters for conversion
-    root_path = Path("E:\CN_data")
+    root_path = Path("E:/CN_data")
     data_dir_path = root_path / "Higley-CN-data-share"
     output_dir_path = root_path / "Higley-conversion_nwb"
     stub_test = True
-    session_id = "11222019_grabAM06_vis_stim"
-    folder_path = data_dir_path / Path(session_id)
+    date = "11222019"
+    animal_number = "05"
+    session_id = f"{date}_grabAM{animal_number}_vis_stim"
+    folder_path = data_dir_path / session_id
+    parcellation_folder_path = (
+        data_dir_path / "parcellation" / f"grab{animal_number}" / "imaging with 575 excitation" / session_id
+    )
     session_to_nwb(
         folder_path=folder_path,
+        parcellation_folder_path=parcellation_folder_path,
         output_dir_path=output_dir_path,
         session_id=session_id,
         stub_test=stub_test,

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_metadata.yaml
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_metadata.yaml
@@ -9,10 +9,10 @@ NWBFile:
   lab: Higley
   experimenter:
     - Moberly, Andrew # others
-  surgery: All surgical implantation procedures were performed on adult mice (>P50). Mice were anesthetized using 1-2% isoflurane and maintained at 37 °C for the duration of the surgery. The skin and fascia above the skull were removed from the nasal bone to the posterior of the intraparietal bone and laterally between the temporal muscles. The surface of the skull was thoroughly cleaned with saline, and the edges of the incision were secured to the skull with Vetbond. A custom titanium headpost was secured to the posterior of the nasal bone with trans-parent dental cement (Metabond, Parkell), and a thin layer of dental cement was applied to the entire dorsal surface of the skull. Next, alayer of cyanoacrylate (Maxi-Cure, Bob Smith Industries) was used to cover the skull and left to cure approximately 30 min at 22-24 °C room temperature to provide a smooth surface for transcranial imaging.
+  surgery: All surgical implantation procedures were performed on adult mice (>P50D). Mice were anesthetized using 1-2% isoflurane and maintained at 37 °C for the duration of the surgery. The skin and fascia above the skull were removed from the nasal bone to the posterior of the intraparietal bone and laterally between the temporal muscles. The surface of the skull was thoroughly cleaned with saline, and the edges of the incision were secured to the skull with Vetbond. A custom titanium headpost was secured to the posterior of the nasal bone with trans-parent dental cement (Metabond, Parkell), and a thin layer of dental cement was applied to the entire dorsal surface of the skull. Next, alayer of cyanoacrylate (Maxi-Cure, Bob Smith Industries) was used to cover the skull and left to cure approximately 30 min at 22-24 °C room temperature to provide a smooth surface for transcranial imaging.
   virus: Pups were injected bilaterally with 2 μl of AAV9-hsyn-ACh3.0 (1.8 x 1013 gc / ml) and 2 μl of AAV9-hsyn-NES-jRCaMP1b (2.5 x 1013 gc / ml; Addgene) per hemisphere.
 Subject:
   species: Mus musculus
-  age: P1W2D # to be modified for each subject
-  sex: M 
+  age: P60D/P100D
+  sex: U
   strain: C57BL/6J

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_metadata.yaml
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_metadata.yaml
@@ -1,12 +1,18 @@
 NWBFile:
-  session_description:
-    A rich text description of the experiment. Can also just be the abstract of the publication.
-  institution: Institution where the lab is located
+  related_publications:
+    - https://www.nature.com/articles/s41593-022-01202-6
+    - https://github.com/cardin-higley-lab/Lohani_Moberly_et_al_2022
+  keywords: [Dual-color mesoscopic ACh, calcium imaging, visual stimulus, mouse]
+  experiment_description: Dual-color mesoscopic imaging of both ACh and calcium across the neocortex of awake mice to investigate their relationships with behavioral variables. We find that higher arousal, categorized by diferent motor behaviors, is associated with spatiotemporally dynamic patterns of cholinergic modulation and enhanced large-scale network correlations. Overall, our fndings demonstrate that ACh provides a highly dynamic and spatially heterogeneous signal that links fuctuations in behavior to functional reorganization of cortical networks.
+  session_description: Dual-color mesoscopic imaging of both ACh and calcium across the neocortex of awake mice. All imaging was performed during the second half of the light cycle in awake, behaving mice that were head-fixed so that they could freely run on a cylindrical wheel. Small (20° diameter) sinusoidal drifting gratings (2 Hz, 0.04 cycles per degree, 100% contrast) were generated using Psychtoolbox in MATLAB and presented on an LCD monitor at a distance of 20 cm. Stimuli were presented for 1-2 s. Air-puff stimuli were delivered using a thin metal tube aimed at the fur along the back and coupled to a solenoid valve (Clark Solutions) that delivered brief (200-ms) puffs of compressed air.
+  institution: Yale University School of Medicine
   lab: Higley
   experimenter:
-    - Last, First Middle
-    - Last, First Middle
+    - Moberly, Andrew # others
+  surgery: All surgical implantation procedures were performed on adult mice (>P50). Mice were anesthetized using 1-2% isoflurane and maintained at 37 °C for the duration of the surgery. The skin and fascia above the skull were removed from the nasal bone to the posterior of the intraparietal bone and laterally between the temporal muscles. The surface of the skull was thoroughly cleaned with saline, and the edges of the incision were secured to the skull with Vetbond. A custom titanium headpost was secured to the posterior of the nasal bone with trans-parent dental cement (Metabond, Parkell), and a thin layer of dental cement was applied to the entire dorsal surface of the skull. Next, alayer of cyanoacrylate (Maxi-Cure, Bob Smith Industries) was used to cover the skull and left to cure approximately 30 min at 22-24 °C room temperature to provide a smooth surface for transcranial imaging.
+  virus: Pups were injected bilaterally with 2 μl of AAV9-hsyn-ACh3.0 (1.8 x 1013 gc / ml) and 2 μl of AAV9-hsyn-NES-jRCaMP1b (2.5 x 1013 gc / ml; Addgene) per hemisphere.
 Subject:
-  species: Rattus norvegicus
-  age: P1W2D  # in ISO 8601, such as "P1W2D"
-  sex: U  # One of M, F, U, or O
+  species: Mus musculus
+  age: P1W2D # to be modified for each subject
+  sex: M # One of M, F, U, or O
+  strain: C57BL/6J

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_metadata.yaml
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_metadata.yaml
@@ -14,5 +14,5 @@ NWBFile:
 Subject:
   species: Mus musculus
   age: P1W2D # to be modified for each subject
-  sex: M # One of M, F, U, or O
+  sex: M 
   strain: C57BL/6J

--- a/src/higley_lab_to_nwb/lohani_2022/metadata/lohani_2022_ophys_metadata.yaml
+++ b/src/higley_lab_to_nwb/lohani_2022/metadata/lohani_2022_ophys_metadata.yaml
@@ -12,18 +12,6 @@ Ophys:
       description: Imaging data from Green channel recorded with Violet excitation.
       imaging_plane: ImagingPlaneVioletExcitationGreenChannel
       unit: n.a.
-    - name: OnePhotonSeriesGreenExcitationGreenChannel
-      description: Imaging data from Green channel recorded with Green excitation.
-      imaging_plane: ImagingPlaneGreenExcitationGreenChannel
-      unit: n.a.
-    - name: OnePhotonSeriesBlueExcitationRedChannel
-      description: Imaging data from Red channel recorded with Blue excitation.
-      imaging_plane: ImagingPlaneBlueExcitationRedChannel
-      unit: n.a.
-    - name: OnePhotonSeriesVioletExcitationRedChannel
-      description: Imaging data from Red channel recorded with Violet excitation.
-      imaging_plane: ImagingPlaneVioletExcitationRedChannel
-      unit: n.a.
     - name: OnePhotonSeriesGreenExcitationRedChannel
       description: Imaging data from Red channel recorded with Green excitation.
       imaging_plane: ImagingPlaneGreenExcitationRedChannel
@@ -38,7 +26,7 @@ Ophys:
         - name: Green
           description: Green channel of the microscope, 525/50 nm filter.
           emission_lambda: 525.0
-      indicator: jRCaMP1b
+      indicator: ACh3.0
     - name: ImagingPlaneVioletExcitationGreenChannel
       description: Imaging plane for the Green channel recorded with Violet excitation.
       excitation_lambda: 395.0  # in nm
@@ -48,36 +36,6 @@ Ophys:
         - name: Green
           description: Green channel of the microscope, 525/50 nm filter.
           emission_lambda: 525.0
-      indicator: jRCaMP1b
-    - name: ImagingPlaneGreenExcitationGreenChannel
-      description: Imaging plane for the Green channel recorded with Green excitation.
-      excitation_lambda: 575.0  # in nm
-      location: Whole Brain
-      device: OnePhotonMicroscope
-      optical_channel:
-        - name: Green
-          description: Green channel of the microscope, 525/50 nm filter.
-          emission_lambda: 525.0
-      indicator: jRCaMP1b
-    - name: ImagingPlaneBlueExcitationRedChannel
-      description: Imaging plane for the Red channel recorded with Blue excitation.
-      excitation_lambda: 470.0  # in nm
-      location: Whole Brain
-      device: OnePhotonMicroscope
-      optical_channel:
-        - name: Red
-          description: Red channel of the microscope, 630/75 nm filter.
-          emission_lambda: 630.0
-      indicator: ACh3.0
-    - name: ImagingPlaneVioletExcitationRedChannel
-      description: Imaging plane for the Red channel recorded with Violet excitation.
-      excitation_lambda: 395.0  # in nm
-      location: Whole Brain
-      device: OnePhotonMicroscope
-      optical_channel:
-        - name: Red
-          description: Red channel of the microscope, 630/75 nm filter.
-          emission_lambda: 630.0
       indicator: ACh3.0
     - name: ImagingPlaneGreenExcitationRedChannel
       description: Imaging plane for the Red channel recorded with Green excitation.
@@ -88,4 +46,4 @@ Ophys:
         - name: Red
           description: Red channel of the microscope, 630/75 nm filter.
           emission_lambda: 630.0
-      indicator: ACh3.0
+      indicator: jRCaMP1b

--- a/src/higley_lab_to_nwb/lohani_2022/utils/__init__.py
+++ b/src/higley_lab_to_nwb/lohani_2022/utils/__init__.py
@@ -1,1 +1,7 @@
-from .lohani_2022_utils import read_session_start_time, get_tiff_file_paths_sorted_by_channel, create_tiff_stack
+from .lohani_2022_utils import (
+    read_session_start_time,
+    get_tiff_file_paths_sorted_by_channel,
+    create_tiff_stack,
+    get_event_times_from_mat,
+    get_event_times_from_spike2,
+)

--- a/src/higley_lab_to_nwb/lohani_2022/utils/lohani_2022_utils.py
+++ b/src/higley_lab_to_nwb/lohani_2022/utils/lohani_2022_utils.py
@@ -3,22 +3,26 @@ from natsort import natsorted
 import numpy as np
 from datetime import datetime
 from zoneinfo import ZoneInfo
+from neuroconv.tools.signal_processing import get_rising_frames_from_ttl, get_falling_frames_from_ttl
+from spikeinterface.extractors import CedRecordingExtractor
+from neuroconv.tools import get_package
+
 
 def read_session_start_time(folder_path):
     tiff_file_paths = natsorted(folder_path.glob("*.tif"))
     with tifffile.TiffFile(tiff_file_paths[0]) as tif:
-        metadata = tif.pages[0].tags['ImageDescription'].value
+        metadata = tif.pages[0].tags["ImageDescription"].value
 
-    lines = metadata.split('\r\n')
+    lines = metadata.split("\r\n")
     date_time_str = lines[1]
     # Assuming the timezone is always 'Eastern Standard Time'
-    date_time_obj = datetime.strptime(date_time_str[:-len(' Eastern Standard Time')], '%a, %d %b %Y %H:%M:%S')
-    date_time_obj = date_time_obj.replace(tzinfo=ZoneInfo('US/Eastern'))
-    
+    date_time_obj = datetime.strptime(date_time_str[: -len(" Eastern Standard Time")], "%a, %d %b %Y %H:%M:%S")
+    date_time_obj = date_time_obj.replace(tzinfo=ZoneInfo("US/Eastern"))
+
     return date_time_obj
 
-def get_tiff_file_paths_sorted_by_channel(folder_path: str, start_frame_index: int = 0, stub_test: bool = False):
 
+def get_tiff_file_paths_sorted_by_channel(folder_path: str, start_frame_index: int = 0, stub_test: bool = False):
     tiff_file_paths = natsorted(folder_path.glob("*.tif"))
     if stub_test:
         tiff_file_paths = tiff_file_paths[:100]  # for testing
@@ -27,20 +31,76 @@ def get_tiff_file_paths_sorted_by_channel(folder_path: str, start_frame_index: i
     return selected_tiff_file_paths
 
 
-def create_tiff_stack(folder_path: str, output_file_path: str, start_frame_index: int = 0, frame_side: str = "left", stub_test: bool = False):
-    
+def create_tiff_stack(
+    folder_path: str,
+    output_file_path: str,
+    start_frame_index: int = 0,
+    frame_side: str = "left",
+    stub_test: bool = False,
+):
     selected_tiff_file_paths = get_tiff_file_paths_sorted_by_channel(
-        folder_path=folder_path, start_frame_index=start_frame_index, stub_test = stub_test
+        folder_path=folder_path, start_frame_index=start_frame_index, stub_test=stub_test
     )
     frames = [tifffile.imread(file_path) for file_path in selected_tiff_file_paths]
 
     if frame_side == "left":
-        stack = np.stack([frame[:, :512].transpose(1,0) for frame in frames], axis=0)
+        stack = np.stack([frame[:, :512].transpose(1, 0) for frame in frames], axis=0)
     elif frame_side == "right":
-        stack = np.stack([frame[:, 512:].transpose(1,0)  for frame in frames], axis=0)
+        stack = np.stack([frame[:, 512:].transpose(1, 0) for frame in frames], axis=0)
     else:
         raise ValueError("frame_side must be either 'right' or 'left'")
 
     tifffile.imwrite(output_file_path, stack)
 
-    return 
+    return
+
+
+def process_event_times(rising_times: np.ndarray, falling_times: np.ndarray):
+    # TODO define your custom function to processed event times extracted from Spike2 signal
+    return rising_times, falling_times
+
+
+def _test_sonpy_installation() -> None:
+    get_package(
+        package_name="sonpy",
+        excluded_python_versions=["3.10", "3.11"],
+        excluded_platforms_and_python_versions=dict(darwin=dict(arm=["3.8", "3.9", "3.10", "3.11"])),
+    )
+
+
+def get_event_times_from_spike2(file_path: str, stream_id: str, clean_event_times: bool = False):
+    _test_sonpy_installation()
+    extractor = CedRecordingExtractor(file_path=file_path, stream_id=stream_id)
+    times = extractor.get_times()
+    traces = extractor.get_traces()
+    rising_times = get_rising_frames_from_ttl(traces)
+    falling_times = get_falling_frames_from_ttl(traces)
+    if clean_event_times:
+        process_event_times(rising_times, falling_times)
+    start_times = times[rising_times]
+    stop_times = times[falling_times]
+    return start_times, stop_times
+
+
+def get_event_times_from_mat(
+    file_path: str,
+):
+    from pymatreader import read_mat
+
+    mat = read_mat(str(file_path))
+
+    if "timing" in mat:
+        timing_group = mat["timing"]
+        # Check if the stimstart and stimend dataset exists
+        if "stimstart" in timing_group and "stimend" in timing_group:
+            start_times_data = timing_group["stimstart"]
+            start_times = start_times_data[:]
+            stop_times_data = timing_group["stimend"]
+            stop_times = stop_times_data[:]
+            return start_times, stop_times
+        elif "stimstart" not in timing_group:
+            raise f"stimstart dataset does not exists in {file_path}"
+        elif "stimend" not in timing_group:
+            raise f"stimend dataset does not exists in {file_path}"
+    else:
+        raise f"timing group does not exists in {file_path}"


### PR DESCRIPTION
Review #29 first
Update visual stimulus interface to read timestamps from matlab file. A custom function for extracted events curation has been added to provide the lab with an alternative solution.
This PR fix #21 by providing `start_times` and `stop_times` as input of the VisualStimulusInterface. utils functions have been implemented for each of the conversion project to extract timestamps either from matlab file (already curated timestamps) or spike2 output (with an optional custom function to curate event times that the user can set).