### PR TITLE
Add custom facemap interface

### DIFF
--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_2p_only_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_2p_only_session.py
@@ -139,7 +139,7 @@ def session_to_nwb(
                 mat_file_path=str(mat_file_path),
                 video_file_path=str(video_file_path),
                 svd_mask_names=["Face"],
-                first_n_components=10,
+                first_n_components=10 if stub_test else 500,
                 verbose=False,
             )
         )

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_2p_only_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_2p_only_session.py
@@ -131,13 +131,19 @@ def session_to_nwb(
     conversion_options.update(dict(Video=dict(stub_test=stub_test)))
 
     # Add Facemap outpt
-    # mat_files = list(folder_path.glob(f"{search_pattern}*_proc.mat"))
-    # mat_file_path = mat_files[0]
-    # source_data.update(
-    #     dict(
-    #         FacemapInterface=dict(mat_file_path=str(mat_file_path), video_file_path=str(video_file_path), verbose=False)
-    #     )
-    # )
+    mat_files = list(folder_path.glob(f"{search_pattern}*_proc.mat"))
+    mat_file_path = mat_files[0]
+    source_data.update(
+        dict(
+            FacemapInterface=dict(
+                mat_file_path=str(mat_file_path),
+                video_file_path=str(video_file_path),
+                svd_mask_names=["Face"],
+                first_n_components=10,
+                verbose=False,
+            )
+        )
+    )
 
     # Add ophys metadata
     ophys_metadata_path = Path(__file__).parent / "metadata" / "benisty_2024_ophys_2p_only_metadata.yaml"
@@ -165,7 +171,7 @@ def session_to_nwb(
 if __name__ == "__main__":
 
     # Parameters for conversion
-    root_path = Path("/media/amtra/Samsung_T5/CN_data")
+    root_path = Path("F:/CN_data")
     data_dir_path = root_path / "Higley-CN-data-share"
     output_dir_path = root_path / "Higley-conversion_nwb/"
     stub_test = True

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_2p_only_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_2p_only_session.py
@@ -171,7 +171,7 @@ def session_to_nwb(
 if __name__ == "__main__":
 
     # Parameters for conversion
-    root_path = Path("F:/CN_data")
+    root_path = Path("G:")
     data_dir_path = root_path / "Higley-CN-data-share"
     output_dir_path = root_path / "Higley-conversion_nwb/"
     stub_test = True

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -216,7 +216,7 @@ def dual_imaging_session_to_nwb(
 if __name__ == "__main__":
 
     # Parameters for conversion
-    root_path = Path("E:/CN_data")
+    root_path = Path("F:/CN_data")
     data_dir_path = root_path / "Higley-CN-data-share/Dual 2p Meso data"
     output_dir_path = root_path / "Higley-conversion_nwb/"
     stub_test = True

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -15,6 +15,7 @@ def dual_imaging_session_to_nwb(
     session_id: str,
     stub_test: bool = False,
 ):
+    folder_path = data_dir_path / f"{subject_id}_1p"
 
     output_dir_path = Path(output_dir_path)
     if stub_test:
@@ -124,92 +125,92 @@ def dual_imaging_session_to_nwb(
         )
     )
 
-    # # Add processed imaging data
-    # processed_imaging_path = meso_imaging_path / f"{session_id}"
-    # # add Df_over_f imaging data from blue excitation
-    # file_path = processed_imaging_path / f"FIR_dff_blue.mat"
-    # source_data.update(
-    #     dict(
-    #         DffOnePhotonImaging=dict(
-    #             file_path=str(file_path),
-    #             sampling_frequency=sampling_frequency,
-    #             process_type="dff_blue",
-    #         )
-    #     )
-    # )
-    # conversion_options.update(
-    #     dict(
-    #         DffOnePhotonImaging=dict(
-    #             stub_test=stub_test,
-    #             photon_series_type="OnePhotonSeries",
-    #             photon_series_index=2,
-    #             parent_container="processing/ophys",
-    #         )
-    #     )
-    # )
-    # # add Df_over_f imaging data from violet excitation (isosbestic control)
-    # file_path = processed_imaging_path / f"FIR_dff_uv.mat"
-    # source_data.update(
-    #     dict(
-    #         DffOnePhotonImagingIsosbestic=dict(
-    #             file_path=str(file_path),
-    #             sampling_frequency=sampling_frequency,
-    #             process_type="dff_uv",
-    #         )
-    #     )
-    # )
-    # conversion_options.update(
-    #     dict(
-    #         DffOnePhotonImagingIsosbestic=dict(
-    #             stub_test=stub_test,
-    #             photon_series_type="OnePhotonSeries",
-    #             photon_series_index=3,
-    #             parent_container="processing/ophys",
-    #         )
-    #     )
-    # )
-    # # add hemodynamic corrected imaging data
-    # file_path = processed_imaging_path / f"FIR_DFF_patch11_final_dFoF.mat"
-    # source_data.update(
-    #     dict(
-    #         HemodynamicCorrectedOnePhotonImaging=dict(
-    #             file_path=str(file_path),
-    #             sampling_frequency=sampling_frequency,
-    #             process_type="dff_final",
-    #         )
-    #     )
-    # )
-    # conversion_options.update(
-    #     dict(
-    #         HemodynamicCorrectedOnePhotonImaging=dict(
-    #             stub_test=stub_test,
-    #             photon_series_type="OnePhotonSeries",
-    #             photon_series_index=4,
-    #             parent_container="processing/ophys",
-    #         )
-    #     )
-    # )
+    # Add processed imaging data
+    processed_imaging_path = meso_imaging_path / f"{session_id}"
+    # add Df_over_f imaging data from blue excitation
+    file_path = processed_imaging_path / f"FIR_dff_blue.mat"
+    source_data.update(
+        dict(
+            DffOnePhotonImaging=dict(
+                file_path=str(file_path),
+                sampling_frequency=sampling_frequency,
+                process_type="dff_blue",
+            )
+        )
+    )
+    conversion_options.update(
+        dict(
+            DffOnePhotonImaging=dict(
+                stub_test=stub_test,
+                photon_series_type="OnePhotonSeries",
+                photon_series_index=2,
+                parent_container="processing/ophys",
+            )
+        )
+    )
+    # add Df_over_f imaging data from violet excitation (isosbestic control)
+    file_path = processed_imaging_path / f"FIR_dff_uv.mat"
+    source_data.update(
+        dict(
+            DffOnePhotonImagingIsosbestic=dict(
+                file_path=str(file_path),
+                sampling_frequency=sampling_frequency,
+                process_type="dff_uv",
+            )
+        )
+    )
+    conversion_options.update(
+        dict(
+            DffOnePhotonImagingIsosbestic=dict(
+                stub_test=stub_test,
+                photon_series_type="OnePhotonSeries",
+                photon_series_index=3,
+                parent_container="processing/ophys",
+            )
+        )
+    )
+    # add hemodynamic corrected imaging data
+    file_path = processed_imaging_path / f"FIR_DFF_patch11_final_dFoF.mat"
+    source_data.update(
+        dict(
+            HemodynamicCorrectedOnePhotonImaging=dict(
+                file_path=str(file_path),
+                sampling_frequency=sampling_frequency,
+                process_type="dff_final",
+            )
+        )
+    )
+    conversion_options.update(
+        dict(
+            HemodynamicCorrectedOnePhotonImaging=dict(
+                stub_test=stub_test,
+                photon_series_type="OnePhotonSeries",
+                photon_series_index=4,
+                parent_container="processing/ophys",
+            )
+        )
+    )
 
     # # Add Behavioral Video Recording
     # avi_files = list(folder_path.glob(f"{session_id}*.avi"))
     # video_file_path = avi_files[0]
     # source_data.update(dict(Video=dict(file_paths=[video_file_path], verbose=False)))
     # conversion_options.update(dict(Video=dict(stub_test=stub_test)))
-    
-    # just for testing the facemap interface
-    video_file_path="/media/amtra/Seagate Expansion Drive/CN_data/Higley-CN-data-share/04072021_am2psi_05_spont/04072021_am2psi_05_spont_facevideo.avi"
+
+    # TODO remove this line of code once actual behavioral video is shared
+    video_file_path = "/media/amtra/Seagate Expansion Drive/CN_data/Higley-CN-data-share/04072021_am2psi_05_spont/04072021_am2psi_05_spont_facevideo.avi"
 
     # Add Facemap outpt
     mat_files = list(folder_path.glob(f"{session_id}*_proc.mat"))
     for mat_file in mat_files:
-        if "inverted" not in mat_file:
+        if "inverted" not in str(mat_file):
             mat_file_path = mat_file
     source_data.update(
         dict(
             FacemapPythonInterface=dict(
                 mat_file_path=str(mat_file_path),
                 video_file_path=str(video_file_path),
-                svd_mask_names=["Face","Whiskers", "Pupil"],
+                svd_mask_names=["Face", "Whiskers", "Pupil"],  # TODO check with the lab point person
                 first_n_components=10 if stub_test else None,
                 verbose=False,
             )
@@ -242,7 +243,7 @@ def dual_imaging_session_to_nwb(
 if __name__ == "__main__":
 
     # Parameters for conversion
-    root_path = Path("/media/amtra/Seagate Expansion Drive/CN_data")
+    root_path = Path("F:/CN_data")
     data_dir_path = root_path / "Higley-CN-data-share/Dual 2p Meso data"
     output_dir_path = root_path / "Higley-conversion_nwb/"
     stub_test = True

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -124,68 +124,94 @@ def dual_imaging_session_to_nwb(
         )
     )
 
-    # Add processed imaging data
-    processed_imaging_path = meso_imaging_path / f"{session_id}"
-    # add Df_over_f imaging data from blue excitation
-    file_path = processed_imaging_path / f"FIR_dff_blue.mat"
+    # # Add processed imaging data
+    # processed_imaging_path = meso_imaging_path / f"{session_id}"
+    # # add Df_over_f imaging data from blue excitation
+    # file_path = processed_imaging_path / f"FIR_dff_blue.mat"
+    # source_data.update(
+    #     dict(
+    #         DffOnePhotonImaging=dict(
+    #             file_path=str(file_path),
+    #             sampling_frequency=sampling_frequency,
+    #             process_type="dff_blue",
+    #         )
+    #     )
+    # )
+    # conversion_options.update(
+    #     dict(
+    #         DffOnePhotonImaging=dict(
+    #             stub_test=stub_test,
+    #             photon_series_type="OnePhotonSeries",
+    #             photon_series_index=2,
+    #             parent_container="processing/ophys",
+    #         )
+    #     )
+    # )
+    # # add Df_over_f imaging data from violet excitation (isosbestic control)
+    # file_path = processed_imaging_path / f"FIR_dff_uv.mat"
+    # source_data.update(
+    #     dict(
+    #         DffOnePhotonImagingIsosbestic=dict(
+    #             file_path=str(file_path),
+    #             sampling_frequency=sampling_frequency,
+    #             process_type="dff_uv",
+    #         )
+    #     )
+    # )
+    # conversion_options.update(
+    #     dict(
+    #         DffOnePhotonImagingIsosbestic=dict(
+    #             stub_test=stub_test,
+    #             photon_series_type="OnePhotonSeries",
+    #             photon_series_index=3,
+    #             parent_container="processing/ophys",
+    #         )
+    #     )
+    # )
+    # # add hemodynamic corrected imaging data
+    # file_path = processed_imaging_path / f"FIR_DFF_patch11_final_dFoF.mat"
+    # source_data.update(
+    #     dict(
+    #         HemodynamicCorrectedOnePhotonImaging=dict(
+    #             file_path=str(file_path),
+    #             sampling_frequency=sampling_frequency,
+    #             process_type="dff_final",
+    #         )
+    #     )
+    # )
+    # conversion_options.update(
+    #     dict(
+    #         HemodynamicCorrectedOnePhotonImaging=dict(
+    #             stub_test=stub_test,
+    #             photon_series_type="OnePhotonSeries",
+    #             photon_series_index=4,
+    #             parent_container="processing/ophys",
+    #         )
+    #     )
+    # )
+
+    # # Add Behavioral Video Recording
+    # avi_files = list(folder_path.glob(f"{session_id}*.avi"))
+    # video_file_path = avi_files[0]
+    # source_data.update(dict(Video=dict(file_paths=[video_file_path], verbose=False)))
+    # conversion_options.update(dict(Video=dict(stub_test=stub_test)))
+    
+    # just for testing the facemap interface
+    video_file_path="/media/amtra/Seagate Expansion Drive/CN_data/Higley-CN-data-share/04072021_am2psi_05_spont/04072021_am2psi_05_spont_facevideo.avi"
+
+    # Add Facemap outpt
+    mat_files = list(folder_path.glob(f"{session_id}*_proc.mat"))
+    for mat_file in mat_files:
+        if "inverted" not in mat_file:
+            mat_file_path = mat_file
     source_data.update(
         dict(
-            DffOnePhotonImaging=dict(
-                file_path=str(file_path),
-                sampling_frequency=sampling_frequency,
-                process_type="dff_blue",
-            )
-        )
-    )
-    conversion_options.update(
-        dict(
-            DffOnePhotonImaging=dict(
-                stub_test=stub_test,
-                photon_series_type="OnePhotonSeries",
-                photon_series_index=2,
-                parent_container="processing/ophys",
-            )
-        )
-    )
-    # add Df_over_f imaging data from violet excitation (isosbestic control)
-    file_path = processed_imaging_path / f"FIR_dff_uv.mat"
-    source_data.update(
-        dict(
-            DffOnePhotonImagingIsosbestic=dict(
-                file_path=str(file_path),
-                sampling_frequency=sampling_frequency,
-                process_type="dff_uv",
-            )
-        )
-    )
-    conversion_options.update(
-        dict(
-            DffOnePhotonImagingIsosbestic=dict(
-                stub_test=stub_test,
-                photon_series_type="OnePhotonSeries",
-                photon_series_index=3,
-                parent_container="processing/ophys",
-            )
-        )
-    )
-    # add hemodynamic corrected imaging data
-    file_path = processed_imaging_path / f"FIR_DFF_patch11_final_dFoF.mat"
-    source_data.update(
-        dict(
-            HemodynamicCorrectedOnePhotonImaging=dict(
-                file_path=str(file_path),
-                sampling_frequency=sampling_frequency,
-                process_type="dff_final",
-            )
-        )
-    )
-    conversion_options.update(
-        dict(
-            HemodynamicCorrectedOnePhotonImaging=dict(
-                stub_test=stub_test,
-                photon_series_type="OnePhotonSeries",
-                photon_series_index=4,
-                parent_container="processing/ophys",
+            FacemapPythonInterface=dict(
+                mat_file_path=str(mat_file_path),
+                video_file_path=str(video_file_path),
+                svd_mask_names=["Face","Whiskers", "Pupil"],
+                first_n_components=10 if stub_test else None,
+                verbose=False,
             )
         )
     )
@@ -216,12 +242,12 @@ def dual_imaging_session_to_nwb(
 if __name__ == "__main__":
 
     # Parameters for conversion
-    root_path = Path("F:/CN_data")
+    root_path = Path("/media/amtra/Seagate Expansion Drive/CN_data")
     data_dir_path = root_path / "Higley-CN-data-share/Dual 2p Meso data"
     output_dir_path = root_path / "Higley-conversion_nwb/"
     stub_test = True
     subject_id = "dbvdual035"
-    session_id = "20201231_00002"
+    session_id = "20201230_00001"
     dual_imaging_session_to_nwb(
         data_dir_path=data_dir_path,
         output_dir_path=output_dir_path,

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -231,7 +231,7 @@ def dual_imaging_session_to_nwb(
                         mat_file_path=str(mat_file),
                         video_file_path=str(video_file_path),
                         svd_mask_names=["Face", "Whiskers"],
-                        first_n_components=10,
+                        first_n_components=10 if stub_test else 500,
                         verbose=False,
                     )
                 )

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -98,119 +98,119 @@ def dual_imaging_session_to_nwb(
     source_data.update(dict(TwoPhotonImaging=dict(folder_path=str(imaging_path), file_pattern=file_pattern)))
     conversion_options.update(dict(TwoPhotonImaging=dict(stub_test=stub_test)))
 
-    # # Add Segmentation
-    # suite2p_path = imaging_path / f"{session_id.split('_')[0]}_2p_00001a" / "suite2p"
-    # source_data.update(dict(Suite2pSegmentation=dict(folder_path=suite2p_path)))
-    # conversion_options.update(dict(Suite2pSegmentation=dict(stub_test=stub_test)))
-    #
-    # # Add 1p Imaging
-    # meso_imaging_path = data_dir_path / f"{subject_id}_1p"
-    # file_pattern = f"{session_id.split('_')[0]}_1p_{session_id.split('_')[1]}*.tif"
-    # # # ad hoc extractor for 1p imaging to separate strobing blue vs violet excitation
-    # sampling_frequency = 9.15
-    # number_of_channels = 2
-    #
-    # channel_first_frame_index = 0
-    # source_data.update(
-    #     dict(
-    #         OnePhotonImaging=dict(
-    #             folder_path=str(meso_imaging_path),
-    #             file_pattern=file_pattern,
-    #             number_of_channels=number_of_channels,
-    #             channel_first_frame_index=channel_first_frame_index,
-    #             sampling_frequency=sampling_frequency,
-    #         )
-    #     )
-    # )
-    # conversion_options.update(
-    #     dict(OnePhotonImaging=dict(stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=0))
-    # )
-    #
-    # channel_first_frame_index = 1
-    # source_data.update(
-    #     dict(
-    #         OnePhotonImagingIsosbestic=dict(
-    #             folder_path=str(meso_imaging_path),
-    #             file_pattern=file_pattern,
-    #             number_of_channels=number_of_channels,
-    #             channel_first_frame_index=channel_first_frame_index,
-    #             sampling_frequency=sampling_frequency,
-    #         )
-    #     )
-    # )
-    # conversion_options.update(
-    #     dict(
-    #         OnePhotonImagingIsosbestic=dict(
-    #             stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=1
-    #         )
-    #     )
-    # )
-    #
-    # # Add processed imaging data
-    # processed_imaging_path = meso_imaging_path / f"{session_id}"
-    # # add Df_over_f imaging data from blue excitation
-    # file_path = processed_imaging_path / f"FIR_dff_blue.mat"
-    # source_data.update(
-    #     dict(
-    #         DffOnePhotonImaging=dict(
-    #             file_path=str(file_path),
-    #             sampling_frequency=sampling_frequency,
-    #             process_type="dff_blue",
-    #         )
-    #     )
-    # )
-    # conversion_options.update(
-    #     dict(
-    #         DffOnePhotonImaging=dict(
-    #             stub_test=stub_test,
-    #             photon_series_type="OnePhotonSeries",
-    #             photon_series_index=2,
-    #             parent_container="processing/ophys",
-    #         )
-    #     )
-    # )
-    # # add Df_over_f imaging data from violet excitation (isosbestic control)
-    # file_path = processed_imaging_path / f"FIR_dff_uv.mat"
-    # source_data.update(
-    #     dict(
-    #         DffOnePhotonImagingIsosbestic=dict(
-    #             file_path=str(file_path),
-    #             sampling_frequency=sampling_frequency,
-    #             process_type="dff_uv",
-    #         )
-    #     )
-    # )
-    # conversion_options.update(
-    #     dict(
-    #         DffOnePhotonImagingIsosbestic=dict(
-    #             stub_test=stub_test,
-    #             photon_series_type="OnePhotonSeries",
-    #             photon_series_index=3,
-    #             parent_container="processing/ophys",
-    #         )
-    #     )
-    # )
-    # # add hemodynamic corrected imaging data
-    # file_path = processed_imaging_path / f"FIR_DFF_patch11_final_dFoF.mat"
-    # source_data.update(
-    #     dict(
-    #         HemodynamicCorrectedOnePhotonImaging=dict(
-    #             file_path=str(file_path),
-    #             sampling_frequency=sampling_frequency,
-    #             process_type="dff_final",
-    #         )
-    #     )
-    # )
-    # conversion_options.update(
-    #     dict(
-    #         HemodynamicCorrectedOnePhotonImaging=dict(
-    #             stub_test=stub_test,
-    #             photon_series_type="OnePhotonSeries",
-    #             photon_series_index=4,
-    #             parent_container="processing/ophys",
-    #         )
-    #     )
-    # )
+    # Add Segmentation
+    suite2p_path = imaging_path / f"{session_id.split('_')[0]}_2p_00001a" / "suite2p"
+    source_data.update(dict(Suite2pSegmentation=dict(folder_path=suite2p_path)))
+    conversion_options.update(dict(Suite2pSegmentation=dict(stub_test=stub_test)))
+
+    # Add 1p Imaging
+    meso_imaging_path = data_dir_path / f"{subject_id}_1p"
+    file_pattern = f"{session_id.split('_')[0]}_1p_{session_id.split('_')[1]}*.tif"
+    # # ad hoc extractor for 1p imaging to separate strobing blue vs violet excitation
+    sampling_frequency = 9.15
+    number_of_channels = 2
+
+    channel_first_frame_index = 0
+    source_data.update(
+        dict(
+            OnePhotonImaging=dict(
+                folder_path=str(meso_imaging_path),
+                file_pattern=file_pattern,
+                number_of_channels=number_of_channels,
+                channel_first_frame_index=channel_first_frame_index,
+                sampling_frequency=sampling_frequency,
+            )
+        )
+    )
+    conversion_options.update(
+        dict(OnePhotonImaging=dict(stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=0))
+    )
+
+    channel_first_frame_index = 1
+    source_data.update(
+        dict(
+            OnePhotonImagingIsosbestic=dict(
+                folder_path=str(meso_imaging_path),
+                file_pattern=file_pattern,
+                number_of_channels=number_of_channels,
+                channel_first_frame_index=channel_first_frame_index,
+                sampling_frequency=sampling_frequency,
+            )
+        )
+    )
+    conversion_options.update(
+        dict(
+            OnePhotonImagingIsosbestic=dict(
+                stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=1
+            )
+        )
+    )
+
+    # Add processed imaging data
+    processed_imaging_path = meso_imaging_path / f"{session_id}"
+    # add Df_over_f imaging data from blue excitation
+    file_path = processed_imaging_path / f"FIR_dff_blue.mat"
+    source_data.update(
+        dict(
+            DffOnePhotonImaging=dict(
+                file_path=str(file_path),
+                sampling_frequency=sampling_frequency,
+                process_type="dff_blue",
+            )
+        )
+    )
+    conversion_options.update(
+        dict(
+            DffOnePhotonImaging=dict(
+                stub_test=stub_test,
+                photon_series_type="OnePhotonSeries",
+                photon_series_index=2,
+                parent_container="processing/ophys",
+            )
+        )
+    )
+    # add Df_over_f imaging data from violet excitation (isosbestic control)
+    file_path = processed_imaging_path / f"FIR_dff_uv.mat"
+    source_data.update(
+        dict(
+            DffOnePhotonImagingIsosbestic=dict(
+                file_path=str(file_path),
+                sampling_frequency=sampling_frequency,
+                process_type="dff_uv",
+            )
+        )
+    )
+    conversion_options.update(
+        dict(
+            DffOnePhotonImagingIsosbestic=dict(
+                stub_test=stub_test,
+                photon_series_type="OnePhotonSeries",
+                photon_series_index=3,
+                parent_container="processing/ophys",
+            )
+        )
+    )
+    # add hemodynamic corrected imaging data
+    file_path = processed_imaging_path / f"FIR_DFF_patch11_final_dFoF.mat"
+    source_data.update(
+        dict(
+            HemodynamicCorrectedOnePhotonImaging=dict(
+                file_path=str(file_path),
+                sampling_frequency=sampling_frequency,
+                process_type="dff_final",
+            )
+        )
+    )
+    conversion_options.update(
+        dict(
+            HemodynamicCorrectedOnePhotonImaging=dict(
+                stub_test=stub_test,
+                photon_series_type="OnePhotonSeries",
+                photon_series_index=4,
+                parent_container="processing/ophys",
+            )
+        )
+    )
 
     # # Add Behavioral Video Recording
     # avi_files = list(folder_path.glob(f"{session_id}*.avi"))

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_convert_dual_imaging_session.py
@@ -98,119 +98,119 @@ def dual_imaging_session_to_nwb(
     source_data.update(dict(TwoPhotonImaging=dict(folder_path=str(imaging_path), file_pattern=file_pattern)))
     conversion_options.update(dict(TwoPhotonImaging=dict(stub_test=stub_test)))
 
-    # Add Segmentation
-    suite2p_path = imaging_path / f"{session_id.split('_')[0]}_2p_00001a" / "suite2p"
-    source_data.update(dict(Suite2pSegmentation=dict(folder_path=suite2p_path)))
-    conversion_options.update(dict(Suite2pSegmentation=dict(stub_test=stub_test)))
-
-    # Add 1p Imaging
-    meso_imaging_path = data_dir_path / f"{subject_id}_1p"
-    file_pattern = f"{session_id.split('_')[0]}_1p_{session_id.split('_')[1]}*.tif"
-    # # ad hoc extractor for 1p imaging to separate strobing blue vs violet excitation
-    sampling_frequency = 9.15
-    number_of_channels = 2
-
-    channel_first_frame_index = 0
-    source_data.update(
-        dict(
-            OnePhotonImaging=dict(
-                folder_path=str(meso_imaging_path),
-                file_pattern=file_pattern,
-                number_of_channels=number_of_channels,
-                channel_first_frame_index=channel_first_frame_index,
-                sampling_frequency=sampling_frequency,
-            )
-        )
-    )
-    conversion_options.update(
-        dict(OnePhotonImaging=dict(stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=0))
-    )
-
-    channel_first_frame_index = 1
-    source_data.update(
-        dict(
-            OnePhotonImagingIsosbestic=dict(
-                folder_path=str(meso_imaging_path),
-                file_pattern=file_pattern,
-                number_of_channels=number_of_channels,
-                channel_first_frame_index=channel_first_frame_index,
-                sampling_frequency=sampling_frequency,
-            )
-        )
-    )
-    conversion_options.update(
-        dict(
-            OnePhotonImagingIsosbestic=dict(
-                stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=1
-            )
-        )
-    )
-
-    # Add processed imaging data
-    processed_imaging_path = meso_imaging_path / f"{session_id}"
-    # add Df_over_f imaging data from blue excitation
-    file_path = processed_imaging_path / f"FIR_dff_blue.mat"
-    source_data.update(
-        dict(
-            DffOnePhotonImaging=dict(
-                file_path=str(file_path),
-                sampling_frequency=sampling_frequency,
-                process_type="dff_blue",
-            )
-        )
-    )
-    conversion_options.update(
-        dict(
-            DffOnePhotonImaging=dict(
-                stub_test=stub_test,
-                photon_series_type="OnePhotonSeries",
-                photon_series_index=2,
-                parent_container="processing/ophys",
-            )
-        )
-    )
-    # add Df_over_f imaging data from violet excitation (isosbestic control)
-    file_path = processed_imaging_path / f"FIR_dff_uv.mat"
-    source_data.update(
-        dict(
-            DffOnePhotonImagingIsosbestic=dict(
-                file_path=str(file_path),
-                sampling_frequency=sampling_frequency,
-                process_type="dff_uv",
-            )
-        )
-    )
-    conversion_options.update(
-        dict(
-            DffOnePhotonImagingIsosbestic=dict(
-                stub_test=stub_test,
-                photon_series_type="OnePhotonSeries",
-                photon_series_index=3,
-                parent_container="processing/ophys",
-            )
-        )
-    )
-    # add hemodynamic corrected imaging data
-    file_path = processed_imaging_path / f"FIR_DFF_patch11_final_dFoF.mat"
-    source_data.update(
-        dict(
-            HemodynamicCorrectedOnePhotonImaging=dict(
-                file_path=str(file_path),
-                sampling_frequency=sampling_frequency,
-                process_type="dff_final",
-            )
-        )
-    )
-    conversion_options.update(
-        dict(
-            HemodynamicCorrectedOnePhotonImaging=dict(
-                stub_test=stub_test,
-                photon_series_type="OnePhotonSeries",
-                photon_series_index=4,
-                parent_container="processing/ophys",
-            )
-        )
-    )
+    # # Add Segmentation
+    # suite2p_path = imaging_path / f"{session_id.split('_')[0]}_2p_00001a" / "suite2p"
+    # source_data.update(dict(Suite2pSegmentation=dict(folder_path=suite2p_path)))
+    # conversion_options.update(dict(Suite2pSegmentation=dict(stub_test=stub_test)))
+    #
+    # # Add 1p Imaging
+    # meso_imaging_path = data_dir_path / f"{subject_id}_1p"
+    # file_pattern = f"{session_id.split('_')[0]}_1p_{session_id.split('_')[1]}*.tif"
+    # # # ad hoc extractor for 1p imaging to separate strobing blue vs violet excitation
+    # sampling_frequency = 9.15
+    # number_of_channels = 2
+    #
+    # channel_first_frame_index = 0
+    # source_data.update(
+    #     dict(
+    #         OnePhotonImaging=dict(
+    #             folder_path=str(meso_imaging_path),
+    #             file_pattern=file_pattern,
+    #             number_of_channels=number_of_channels,
+    #             channel_first_frame_index=channel_first_frame_index,
+    #             sampling_frequency=sampling_frequency,
+    #         )
+    #     )
+    # )
+    # conversion_options.update(
+    #     dict(OnePhotonImaging=dict(stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=0))
+    # )
+    #
+    # channel_first_frame_index = 1
+    # source_data.update(
+    #     dict(
+    #         OnePhotonImagingIsosbestic=dict(
+    #             folder_path=str(meso_imaging_path),
+    #             file_pattern=file_pattern,
+    #             number_of_channels=number_of_channels,
+    #             channel_first_frame_index=channel_first_frame_index,
+    #             sampling_frequency=sampling_frequency,
+    #         )
+    #     )
+    # )
+    # conversion_options.update(
+    #     dict(
+    #         OnePhotonImagingIsosbestic=dict(
+    #             stub_test=stub_test, photon_series_type="OnePhotonSeries", photon_series_index=1
+    #         )
+    #     )
+    # )
+    #
+    # # Add processed imaging data
+    # processed_imaging_path = meso_imaging_path / f"{session_id}"
+    # # add Df_over_f imaging data from blue excitation
+    # file_path = processed_imaging_path / f"FIR_dff_blue.mat"
+    # source_data.update(
+    #     dict(
+    #         DffOnePhotonImaging=dict(
+    #             file_path=str(file_path),
+    #             sampling_frequency=sampling_frequency,
+    #             process_type="dff_blue",
+    #         )
+    #     )
+    # )
+    # conversion_options.update(
+    #     dict(
+    #         DffOnePhotonImaging=dict(
+    #             stub_test=stub_test,
+    #             photon_series_type="OnePhotonSeries",
+    #             photon_series_index=2,
+    #             parent_container="processing/ophys",
+    #         )
+    #     )
+    # )
+    # # add Df_over_f imaging data from violet excitation (isosbestic control)
+    # file_path = processed_imaging_path / f"FIR_dff_uv.mat"
+    # source_data.update(
+    #     dict(
+    #         DffOnePhotonImagingIsosbestic=dict(
+    #             file_path=str(file_path),
+    #             sampling_frequency=sampling_frequency,
+    #             process_type="dff_uv",
+    #         )
+    #     )
+    # )
+    # conversion_options.update(
+    #     dict(
+    #         DffOnePhotonImagingIsosbestic=dict(
+    #             stub_test=stub_test,
+    #             photon_series_type="OnePhotonSeries",
+    #             photon_series_index=3,
+    #             parent_container="processing/ophys",
+    #         )
+    #     )
+    # )
+    # # add hemodynamic corrected imaging data
+    # file_path = processed_imaging_path / f"FIR_DFF_patch11_final_dFoF.mat"
+    # source_data.update(
+    #     dict(
+    #         HemodynamicCorrectedOnePhotonImaging=dict(
+    #             file_path=str(file_path),
+    #             sampling_frequency=sampling_frequency,
+    #             process_type="dff_final",
+    #         )
+    #     )
+    # )
+    # conversion_options.update(
+    #     dict(
+    #         HemodynamicCorrectedOnePhotonImaging=dict(
+    #             stub_test=stub_test,
+    #             photon_series_type="OnePhotonSeries",
+    #             photon_series_index=4,
+    #             parent_container="processing/ophys",
+    #         )
+    #     )
+    # )
 
     # # Add Behavioral Video Recording
     # avi_files = list(folder_path.glob(f"{session_id}*.avi"))
@@ -219,24 +219,35 @@ def dual_imaging_session_to_nwb(
     # conversion_options.update(dict(Video=dict(stub_test=stub_test)))
 
     # TODO remove this line of code once actual behavioral video is shared
-    video_file_path = "/media/amtra/Seagate Expansion Drive/CN_data/Higley-CN-data-share/04072021_am2psi_05_spont/04072021_am2psi_05_spont_facevideo.avi"
+    video_file_path = "G:/Higley-CN-data-share/04072021_am2psi_05_spont/04072021_am2psi_05_spont_facevideo.avi"
 
     # Add Facemap outpt
     mat_files = list(folder_path.glob(f"{session_id}*_proc.mat"))
     for mat_file in mat_files:
-        if "inverted" not in str(mat_file):
-            mat_file_path = mat_file
-    source_data.update(
-        dict(
-            FacemapPythonInterface=dict(
-                mat_file_path=str(mat_file_path),
-                video_file_path=str(video_file_path),
-                svd_mask_names=["Face", "Whiskers", "Pupil"],  # TODO check with the lab point person
-                first_n_components=10 if stub_test else None,
-                verbose=False,
+        if "inverted" in str(mat_file):
+            source_data.update(
+                dict(
+                    FacemapInterface=dict(
+                        mat_file_path=str(mat_file),
+                        video_file_path=str(video_file_path),
+                        svd_mask_names=["Face", "Whiskers"],
+                        first_n_components=10,
+                        verbose=False,
+                    )
+                )
             )
-        )
-    )
+        else:
+            source_data.update(
+                dict(
+                    FacemapPythonInterface=dict(
+                        mat_file_path=str(mat_file),
+                        video_file_path=str(video_file_path),
+                        svd_mask_names=["Face", "Whiskers", "Pupil"],  # TODO check with the lab point person
+                        first_n_components=10 if stub_test else None,
+                        verbose=False,
+                    )
+                )
+            )
 
     # Add ophys metadata
     ophys_metadata_path = Path(__file__).parent / "metadata" / "benisty_2024_dual_ophys_metadata.yaml"
@@ -269,7 +280,7 @@ if __name__ == "__main__":
     output_dir_path = root_path / "Higley-conversion_nwb/"
     stub_test = True
     subject_id = "dbvdual035"
-    session_id = "20201231_00002"
+    session_id = "20201231_00001"
     dual_imaging_session_to_nwb(
         data_dir_path=data_dir_path,
         output_dir_path=output_dir_path,

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_metadata.yaml
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_metadata.yaml
@@ -1,6 +1,6 @@
 NWBFile:
   related_publications:
-    - https://www.nature.com/articles/s41593-023-01498-y
+    - https://doi.org/10.1038/s41593-023-01498-y
     - https://github.com/cardin-higley-lab/Benisty_Higley_2023
   keywords: [Dual-color mesoscopic ACh, calcium imaging, visual stimulus, mouse]
   experiment_description: Here, we used wide-field mesoscopic calcium imaging to monitor cortical dynamics in awake mice and developed an approach to quantify rapidly time-varying functional connectivity. We show that spontaneous behaviors are represented by fast changes in both the magnitude and correlational structure of cortical network activity. Combining mesoscopic imaging with simultaneous cellular-resolution two-photon microscopy demonstrated that correlations among neighboring neurons and between local and large-scale networks also encode behavior. Finally, the dynamic functional connectivity of mesoscale signals revealed subnetworks not predicted by traditional anatomical atlas-based parcellation of the cortex. These results provide new insights into how behavioral information is represented across the neocortex and demonstrate an analytical framework for investigating time-varying functional connectivity in neural networks.

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
@@ -11,8 +11,9 @@ from higley_lab_to_nwb.interfaces import (
     CidanSegmentationInterface,
     MesoscopicImagingMultiTiffStackInterface,
     ProcessedImagingInterface,
+    FacemapInterface,
 )
-from neuroconv.datainterfaces import VideoInterface, FacemapInterface
+from neuroconv.datainterfaces import VideoInterface
 
 
 class Benisty2024NWBConverter(NWBConverter):

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
@@ -13,6 +13,7 @@ from higley_lab_to_nwb.interfaces import (
     MesoscopicImagingMultiTiffStackInterface,
     ProcessedImagingInterface,
     FacemapInterface,
+    FacemapPythonInterface,
 )
 from neuroconv.datainterfaces import VideoInterface
 
@@ -27,6 +28,7 @@ class Benisty2024NWBConverter(NWBConverter):
         CIDANSegmentation=CidanSegmentationInterface,
         Video=VideoInterface,
         FacemapInterface=FacemapInterface,
+        FacemapPythonInterface=FacemapPythonInterface,
         VisualStimulusInterface=VisualStimulusInterface,
         OnePhotonImaging=MesoscopicImagingMultiTiffStackInterface,
         OnePhotonImagingIsosbestic=MesoscopicImagingMultiTiffStackInterface,

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
@@ -145,4 +145,10 @@ class Benisty2024NWBConverter(NWBConverter):
 
         if "FacemapInterface" in self.data_interface_objects.keys():
             facemap_interface = self.data_interface_objects["FacemapInterface"]
-            facemap_interface.set_aligned_timestamps(video_interface._timestamps[0])
+            # TODO uncomment this line of code once behavioral video is shared
+            # facemap_interface.set_aligned_timestamps(video_interface._timestamps[0])
+
+        if "FacemapPythonInterface" in self.data_interface_objects.keys():
+            facemap_interface = self.data_interface_objects["FacemapPythonInterface"]
+            # TODO uncomment this line of code once behavioral video is shared
+            # facemap_interface.set_aligned_timestamps(video_interface._timestamps[0])

--- a/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
+++ b/src/higley_lab_to_nwb/benisty_2024/benisty_2024_nwbconverter.py
@@ -144,7 +144,5 @@ class Benisty2024NWBConverter(NWBConverter):
             video_interface.set_aligned_starting_time(ttl_times[0])
 
         if "FacemapInterface" in self.data_interface_objects.keys():
-            channel_name = "TTLSignalPupilCamera"
-            ttl_times = ttlsignal_interface.get_event_times_from_ttl_channel_name(channel_name=channel_name)
             facemap_interface = self.data_interface_objects["FacemapInterface"]
-            facemap_interface.set_aligned_starting_time(ttl_times[0])
+            facemap_interface.set_aligned_timestamps(video_interface._timestamps[0])

--- a/src/higley_lab_to_nwb/interfaces/__init__.py
+++ b/src/higley_lab_to_nwb/interfaces/__init__.py
@@ -6,4 +6,4 @@ from .mesoscopic_imaging_interface import (
     MesoscopicImagingMultiTiffSingleFrameInterface,
 )
 from .processing_imaging_interface import ProcessedImagingInterface
-from .facemapdatainterface import FacemapInterface
+from .facemapdatainterface import FacemapInterface, FacemapPythonInterface

--- a/src/higley_lab_to_nwb/interfaces/__init__.py
+++ b/src/higley_lab_to_nwb/interfaces/__init__.py
@@ -3,3 +3,4 @@ from .visual_stimulus_interface import VisualStimulusInterface
 from .cidansegmentation_interface import CidanSegmentationInterface
 from .mesoscopic_imaging_interface import MesoscopicImagingMultiTiffStackInterface
 from .processing_imaging_interface import ProcessedImagingInterface
+from .facemapdatainterface import FacemapInterface

--- a/src/higley_lab_to_nwb/interfaces/external_stimuli_interface.py
+++ b/src/higley_lab_to_nwb/interfaces/external_stimuli_interface.py
@@ -91,9 +91,9 @@ class ExternalStimuliInterface(BaseDataInterface):
         start_times = self.source_data["start_times"]
         stop_times = self.source_data["stop_times"]
 
-        n_frames = 100 if stub_test and len(start_times) < 100 else len(start_times)
+        n_frames = 100 if stub_test and len(start_times) > 100 else len(start_times)
 
-        for frame in range(n_frames - 1):
+        for frame in range(n_frames):
             intervals_table.add_row(
                 start_time=start_times[frame],
                 stop_time=stop_times[frame],
@@ -118,9 +118,9 @@ class ExternalStimuliInterface(BaseDataInterface):
         start_times = self.source_data["start_times"]
         stop_times = self.source_data["stop_times"]
 
-        n_frames = 100 if stub_test else len(start_times)
+        n_frames = 100 if stub_test and len(start_times) > 100 else len(start_times)
 
-        for frame in range(n_frames - 1):
+        for frame in range(n_frames):
             intervals_table.add_row(
                 start_time=start_times[frame],
                 stop_time=stop_times[frame],

--- a/src/higley_lab_to_nwb/interfaces/facemapdatainterface.py
+++ b/src/higley_lab_to_nwb/interfaces/facemapdatainterface.py
@@ -1,0 +1,389 @@
+import subprocess
+import sys
+from typing import Literal, Optional
+
+import h5py
+import numpy as np
+from pynwb.base import TimeSeries
+from pynwb.behavior import EyeTracking, PupilTracking, SpatialSeries
+from pynwb.core import DynamicTableRegion
+from pynwb.file import NWBFile
+
+from neuroconv.utils.dict import DeepDict
+
+from neuroconv import BaseTemporalAlignmentInterface
+from neuroconv.tools import get_module
+from neuroconv.utils import FilePathType, get_base_schema, get_schema_from_hdmf_class
+
+
+def install_package(package):
+    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+
+
+try:
+    from ndx_facemap_motionsvd import MotionSVDMasks, MotionSVDSeries
+except ImportError:
+    # TODO: to be change when ndx-facemap-motionsvd version on pip
+    install_package("git+https://github.com/catalystneuro/ndx-facemap-motionsvd.git@main")
+    from ndx_facemap_motionsvd import MotionSVDMasks, MotionSVDSeries
+
+
+class FacemapInterface(BaseTemporalAlignmentInterface):
+    display_name = "Facemap"
+    help = "Interface for Facemap output."
+
+    keywords = ["eye tracking"]
+
+    def __init__(
+        self,
+        mat_file_path: FilePathType,
+        original_timestamps: list,
+        first_n_components: int = 500,
+        svd_mask_names: list = ["Face"],
+        verbose: bool = True,
+    ):
+        """
+        Load and prepare data for facemap.
+
+        Parameters
+        ----------
+        mat_file_path : string or Path
+            Path to the .mat file.
+        original_timestamps : list
+            The original timestamps from the behavioural video.
+        first_n_components : int, default: 500
+            Number of components to store.
+        svd_mask_names : list, default: ["Face", "Whiskers"]
+            List of names for the motion SVD ROIs.
+        verbose : bool, default: True
+            Allows verbose.
+        """
+        super().__init__(mat_file_path=mat_file_path, verbose=verbose)
+        self.first_n_components = first_n_components
+        self.original_timestamps = original_timestamps
+        self.timestamps = None
+        self.svd_mask_names = svd_mask_names
+
+    def get_metadata_schema(self) -> dict:
+        metadata_schema = super().get_metadata_schema()
+        metadata_schema["properties"]["Behavior"] = get_base_schema(tag="Behavior")
+        spatial_series_metadata_schema = get_schema_from_hdmf_class(SpatialSeries)
+        time_series_metadata_schema = get_schema_from_hdmf_class(TimeSeries)
+        metadata_schema["properties"]["Behavior"].update(
+            required=["EyeTracking", "PupilTracking", "MotionSVDMasks", "MotionSVDSeries"],
+            properties=dict(
+                EyeTracking=dict(
+                    type="array",
+                    minItems=1,
+                    items=spatial_series_metadata_schema,
+                ),
+                PupilTracking=dict(
+                    type="array",
+                    minItems=1,
+                    items=time_series_metadata_schema,
+                ),
+                MotionSVDMasks=dict(
+                    type="object",
+                    properties=dict(
+                        name=dict(type="string"),
+                        description=dict(type="string"),
+                    ),
+                    required=["name", "description"],
+                ),
+                MotionSVDSeries=dict(
+                    type="object",
+                    properties=dict(
+                        name=dict(type="string"),
+                        description=dict(type="string"),
+                    ),
+                    required=["name", "description"],
+                ),
+            ),
+        )
+
+        return metadata_schema
+
+    def get_metadata(self) -> DeepDict:
+        metadata = super().get_metadata()
+        behavior_metadata = dict(
+            EyeTracking=[
+                dict(
+                    name="eye_center_of_mass",
+                    description="The position of the eye measured in degrees.",
+                    reference_frame="unknown",
+                    unit="degrees",
+                )
+            ],
+            PupilTracking=[
+                dict(name="pupil_area", description="Area of pupil.", unit="unknown"),
+                dict(name="pupil_area_raw", description="Raw unprocessed area of pupil.", unit="unknown"),
+            ],
+            MotionSVDMasks=dict(name="MotionSVDMasks", description="Motion masks"),
+            MotionSVDSeries=dict(name="MotionSVDSeries", description="Motion SVD components"),
+        )
+        metadata["Behavior"] = behavior_metadata
+        return metadata
+
+    def add_eye_tracking(self, nwbfile: NWBFile, metadata: DeepDict):
+
+        if self.timestamps is None:
+            self.timestamps = self.get_timestamps()
+        with h5py.File(self.source_data["mat_file_path"], "r") as file:
+            data = file["proc"]["pupil"]["com"][:].T
+
+        behavior_module = get_module(nwbfile=nwbfile, name="behavior", description="behavioral data")
+        eye_tracking_metadata = metadata["Behavior"]["EyeTracking"][0]
+
+        eye_com = SpatialSeries(
+            name=eye_tracking_metadata["name"],
+            description=eye_tracking_metadata["description"],
+            data=data,
+            reference_frame=eye_tracking_metadata["reference_frame"],
+            unit=eye_tracking_metadata["unit"],
+            timestamps=self.timestamps,
+        )
+
+        eye_tracking = EyeTracking(name="EyeTracking", spatial_series=eye_com)
+
+        behavior_module.add(eye_tracking)
+
+    def add_pupil_data(
+        self, nwbfile: NWBFile, metadata: DeepDict, pupil_trace_type: Literal["area_raw", "area"] = "area"
+    ):
+
+        with h5py.File(self.source_data["mat_file_path"], "r") as file:
+
+            behavior_module = get_module(nwbfile=nwbfile, name="behavior", description="behavioral data")
+
+            pupil_area_metadata_ind = 0 if pupil_trace_type == "area" else 1
+            pupil_area_metadata = metadata["Behavior"]["PupilTracking"][pupil_area_metadata_ind]
+
+            if "EyeTracking" not in behavior_module.data_interfaces:
+                self.add_eye_tracking(nwbfile=nwbfile, metadata=metadata)
+
+            eye_tracking_name = metadata["Behavior"]["EyeTracking"][0]["name"]
+            eye_com = behavior_module.data_interfaces["EyeTracking"].spatial_series[eye_tracking_name]
+
+            pupil_trace = TimeSeries(
+                name=pupil_area_metadata["name"],
+                description=pupil_area_metadata["description"],
+                data=file["proc"]["pupil"][pupil_trace_type][:].T,
+                unit=pupil_area_metadata["unit"],
+                timestamps=eye_com,
+            )
+
+            if "PupilTracking" not in behavior_module.data_interfaces:
+                pupil_tracking = PupilTracking(name="PupilTracking")
+                behavior_module.add(pupil_tracking)
+            else:
+                pupil_tracking = behavior_module.data_interfaces["PupilTracking"]
+
+            pupil_tracking.add_timeseries(pupil_trace)
+
+    def add_face_motion_SVD(self, nwbfile: NWBFile, metadata: DeepDict):
+        """
+        Add data motion SVD and motion mask for the whole video.
+
+        Parameters
+        ----------
+        nwbfile : NWBFile
+            NWBFile to add motion SVD components data to.
+        """
+
+        # From documentation
+        # motSVD: cell array of motion SVDs [time x components] (in order: face, ROI1, ROI2, ROI3)
+        # uMotMask: cell array of motion masks [pixels x components]  (in order: face, ROI1, ROI2, ROI3)
+        # motion masks of face are reported as 2D-arrays npixels x
+        if self.timestamps is None:
+            self.timestamps = self.get_timestamps()
+
+        motion_mask_name = metadata["Behavior"]["MotionSVDMasks"]["name"]
+        motion_mask_description = metadata["Behavior"]["MotionSVDMasks"]["description"]
+        motion_series_name = metadata["Behavior"]["MotionSVDSeries"]["name"]
+        motion_series_description = metadata["Behavior"]["MotionSVDSeries"]["description"]
+
+        with h5py.File(self.source_data["mat_file_path"], "r") as file:
+
+            behavior_module = get_module(nwbfile=nwbfile, name="behavior", description="behavioral data")
+
+            # Extract mask_coordinates
+            mask_coordinates = file[file[file["proc"]["ROI"][0][0]][0][0]]
+            y1 = int(np.round(mask_coordinates[0][0]) - 1)  # correct matlab indexing
+            x1 = int(np.round(mask_coordinates[1][0]) - 1)  # correct matlab indexing
+            y2 = y1 + int(np.round(mask_coordinates[2][0]))
+            x2 = x1 + int(np.round(mask_coordinates[3][0]))
+            mask_coordinates = [x1, y1, x2, y2]
+
+            # store face motion mask and motion series
+            motion_masks_table = MotionSVDMasks(
+                name=f"{motion_mask_name}Face",
+                description=f"{motion_mask_description} for face.",
+                mask_coordinates=mask_coordinates,
+                downsampling_factor=self._get_downsamplig_factor(),
+                processed_frame_dimension=self._get_processed_frame_dimension(),
+            )
+
+            # add face mask
+            mask_ref = file["proc"]["uMotMask"][0][0]
+            for c, component in enumerate(file[mask_ref]):
+                if c == self.first_n_components:
+                    break
+                componendt_2d = component.reshape((y2 - y1, x2 - x1))
+                motion_masks_table.add_row(image_mask=componendt_2d.T, check_ragged=False)
+
+            motion_masks = DynamicTableRegion(
+                name="motion_masks",
+                data=list(range(len(file["proc"]["motSVD"][:]))),
+                description="all the face motion mask",
+                table=motion_masks_table,
+            )
+
+            series_ref = file["proc"]["motSVD"][0][0]
+            data = np.array(file[series_ref])
+            data = data[: self.first_n_components, :]
+
+            motion_series = MotionSVDSeries(
+                name=f"{motion_series_name}Face",
+                description=f"{motion_series_description} for face.",
+                data=data.T,
+                motion_masks=motion_masks,
+                unit="unknown",
+                timestamps=self.timestamps,
+            )
+            behavior_module.add(motion_masks_table)
+            behavior_module.add(motion_series)
+
+        return
+
+    def add_motion_SVD(self, nwbfile: NWBFile, metadata: DeepDict, ROI_index: int = 1, ROI_name: str = "ROI1"):
+        """
+        Add data motion SVD and motion mask for each ROI.
+
+        Parameters
+        ----------
+        nwbfile : NWBFile
+            NWBFile to add motion SVD components data to.
+        """
+
+        # From documentation
+        # motSVD: cell array of motion SVDs [time x components] (in order: face, ROI1, ROI2, ROI3)
+        # uMotMask: cell array of motion masks [pixels x components]  (in order: face, ROI1, ROI2, ROI3)
+        # ROIs motion masks are reported as 3D-arrays x_pixels x y_pixels x components
+
+        if self.timestamps is None:
+            self.timestamps = self.get_timestamps()
+
+        motion_mask_name = metadata["Behavior"]["MotionSVDMasks"]["name"]
+        motion_mask_description = metadata["Behavior"]["MotionSVDMasks"]["description"]
+        motion_series_name = metadata["Behavior"]["MotionSVDSeries"]["name"]
+        motion_series_description = metadata["Behavior"]["MotionSVDSeries"]["description"]
+
+        with h5py.File(self.source_data["mat_file_path"], "r") as file:
+
+            behavior_module = get_module(nwbfile=nwbfile, name="behavior", description="behavioral data")
+
+            downsampling_factor = self._get_downsamplig_factor()
+            processed_frame_dimension = self._get_processed_frame_dimension()
+
+            # store ROIs motion mask and motion series
+
+            series_ref = file["proc"]["motSVD"][ROI_index][0]
+            mask_ref = file["proc"]["uMotMask"][ROI_index][0]
+
+            # skipping the first ROI because it refers to "running" mask, from Facemap doc
+            mask_coordinates = file[file["proc"]["locROI"][ROI_index][0]]
+            y1 = int(np.round(mask_coordinates[0][0]) - 1)  # correct matlab indexing
+            x1 = int(np.round(mask_coordinates[1][0]) - 1)  # correct matlab indexing
+            y2 = y1 + int(np.round(mask_coordinates[2][0]))
+            x2 = x1 + int(np.round(mask_coordinates[3][0]))
+            mask_coordinates = [x1, y1, x2, y2]
+
+            motion_masks_table = MotionSVDMasks(
+                name=f"{motion_mask_name}{ROI_name}",
+                description=f"{motion_mask_description} for {ROI_name}",
+                mask_coordinates=mask_coordinates,
+                downsampling_factor=downsampling_factor,
+                processed_frame_dimension=processed_frame_dimension,
+            )
+
+            for c, component in enumerate(file[mask_ref]):
+                if c == self.first_n_components:
+                    break
+                motion_masks_table.add_row(image_mask=component.T, check_ragged=False)
+
+            motion_masks = DynamicTableRegion(
+                name="motion_masks",
+                data=list(range(self.first_n_components)),
+                description="all the ROIs motion mask",
+                table=motion_masks_table,
+            )
+
+            data = np.array(file[series_ref])
+            data = data[: self.first_n_components, :]
+
+            motion_series = MotionSVDSeries(
+                name=f"{motion_series_name}{ROI_name}",
+                description=f"{motion_series_description} for {ROI_name}",
+                data=data.T,
+                motion_masks=motion_masks,
+                unit="unknown",
+                timestamps=self.timestamps,
+            )
+
+            behavior_module.add(motion_masks_table)
+            behavior_module.add(motion_series)
+
+        return
+
+    def get_original_timestamps(self) -> np.ndarray:
+        return self.original_timestamps
+
+    def get_timestamps(self) -> np.ndarray:
+        if self.timestamps is None:
+            return self.get_original_timestamps()
+        else:
+            return self.timestamps
+
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray) -> None:
+        self.timestamps = aligned_timestamps
+
+    def _get_downsamplig_factor(self) -> float:
+        with h5py.File(self.source_data["mat_file_path"], "r") as file:
+            downsamplig_factor = file["proc"]["sc"][0][0]
+        return downsamplig_factor
+
+    def _get_processed_frame_dimension(self) -> np.ndarray:
+        with h5py.File(self.source_data["mat_file_path"], "r") as file:
+            processed_frame_ref = file["proc"]["wpix"][0][0]
+            frame = file[processed_frame_ref]
+            return [frame.shape[1], frame.shape[0]]
+
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: Optional[dict] = None,
+        compression: Optional[str] = "gzip",
+        compression_opts: Optional[int] = None,
+    ):
+        """
+        Add facemap data to NWBFile.
+
+        Parameters
+        ----------
+        nwbfile : NWBFile
+            NWBFile to add facemap data to.
+        metadata : dict, optional
+            Metadata to add to the NWBFile.
+        compression : str, optional
+            Compression type.
+        compression_opts : int, optional
+            Compression options.
+        """
+        # self.add_eye_tracking(nwbfile=nwbfile, metadata=metadata)
+        self.add_pupil_data(nwbfile=nwbfile, metadata=metadata, pupil_trace_type="area_raw")
+        self.add_pupil_data(nwbfile=nwbfile, metadata=metadata, pupil_trace_type="area")
+        self.add_face_motion_SVD(nwbfile=nwbfile, metadata=metadata)
+
+        if len(self.svd_mask_names) > 1:
+            for mask_index, mask_name in enumerate(self.svd_mask_names[1:]):
+                self.add_motion_SVD(nwbfile=nwbfile, metadata=metadata, ROI_index=mask_index, ROI_name=mask_name)

--- a/src/higley_lab_to_nwb/interfaces/processed_behavior_interface.py
+++ b/src/higley_lab_to_nwb/interfaces/processed_behavior_interface.py
@@ -64,7 +64,7 @@ class ProcessedBehaviorInterface(BaseDataInterface):
         )
         n_frames = 100 if stub_test and len(self.wheel_on_times) > 100 else len(self.wheel_on_times)
 
-        for frame in range(n_frames - 1):
+        for frame in range(n_frames):
             intervals_table.add_row(
                 start_time=self.wheel_on_times[frame],
                 stop_time=self.wheel_off_times[frame],

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
@@ -201,7 +201,7 @@ def session_to_nwb(
                 mat_file_path=str(mat_file_path),
                 video_file_path=str(video_file_path),
                 svd_mask_names=["Face", "Whiskers"],
-                first_n_components=10,
+                first_n_components=10 if stub_test else 500,
                 verbose=False,
             )
         )

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
@@ -109,6 +109,7 @@ def session_to_nwb(
             "photon_series_type": "OnePhotonSeries",
         }
         photon_series_index += 1
+
     # Add processed imaging data
     processed_imaging_path = parcellation_folder_path / "final_dFoF.mat"
     for excitation_type, channel in excitation_type_channel_combination.items():
@@ -129,21 +130,27 @@ def session_to_nwb(
         }
         photon_series_index += 1
 
-    # # Add Behavioral Video Recording
-    # avi_files = list(folder_path.glob(f"{search_pattern}*.avi"))
-    # video_file_path = avi_files[0]
-    # source_data.update(dict(Video=dict(file_paths=[video_file_path], verbose=False)))
-    # conversion_options.update(dict(Video=dict(stub_test=stub_test)))
-    #
-    # # Add Facemap output
-    # mat_files = list(folder_path.glob(f"{search_pattern}*_proc.mat"))
-    # mat_file_path = mat_files[0]
-    # source_data.update(
-    #     dict(
-    #         FacemapInterface=dict(mat_file_path=str(mat_file_path), video_file_path=str(video_file_path), verbose=False)
-    #     )
-    # )
-    #
+    # Add Behavioral Video Recording
+    avi_files = list(folder_path.glob(f"{search_pattern}*.avi"))
+    video_file_path = avi_files[0]
+    source_data.update(dict(Video=dict(file_paths=[video_file_path], verbose=False)))
+    conversion_options.update(dict(Video=dict(stub_test=stub_test)))
+
+    # Add Facemap output
+    mat_files = list(folder_path.glob(f"{search_pattern}*_proc.mat"))
+    mat_file_path = mat_files[0]
+    source_data.update(
+        dict(
+            FacemapInterface=dict(
+                mat_file_path=str(mat_file_path),
+                video_file_path=str(video_file_path),
+                svd_mask_names=["Face", "Whiskers"],
+                first_n_components=10,
+                verbose=False,
+            )
+        )
+    )
+
     ophys_metadata_path = Path(__file__).parent / "metadata" / "lohani_2022_ophys_metadata.yaml"
     ophys_metadata = load_dict_from_file(ophys_metadata_path)
 
@@ -177,7 +184,7 @@ if __name__ == "__main__":
     root_path = Path("E:/CN_data")
     data_dir_path = root_path / "Higley-CN-data-share"
     output_dir_path = root_path / "Higley-conversion_nwb"
-    stub_test = False
+    stub_test = True
     date = "11222019"
     animal_number = "05"
     session_id = f"{date}_grabAM{animal_number}_vis_stim"

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
@@ -144,48 +144,48 @@ def session_to_nwb(
         }
         photon_series_index += 1
 
-    # # Add processed imaging data
-    # processed_imaging_path = parcellation_folder_path / "final_dFoF.mat"
-    # for excitation_type, channel in excitation_type_channel_combination.items():
-    #     process_type = excitation_type.lower() if not excitation_type == "Violet" else "uv"
-    #     suffix = f"{excitation_type}Excitation{channel}Channel"
-    #     interface_name = f"DFFImaging{suffix}"
-    #     source_data[interface_name] = {
-    #         "file_path": processed_imaging_path,
-    #         "sampling_frequency": sampling_frequency,
-    #         "photon_series_type": "OnePhotonSeries",
-    #         "process_type": process_type,
-    #     }
-    #     conversion_options[interface_name] = {
-    #         "stub_test": stub_test,
-    #         "photon_series_index": photon_series_index,
-    #         "photon_series_type": "OnePhotonSeries",
-    #         "parent_container": "processing/ophys",
-    #     }
-    #     photon_series_index += 1
-    #
-    # # Add parcellation output data
-    # mat_file_path = list(parcellation_folder_path.glob(f"green_{session_id}*.mat"))[0]
-    # plane_segmentation_name = "ParcellatedPlaneSegmentation"
-    # source_data.update(
-    #     dict(
-    #         ParcellsSegmentationInterface=dict(
-    #             file_path=mat_file_path,
-    #             sampling_frequency=sampling_frequency,
-    #             image_size=[256, 256],
-    #             plane_segmentation_name=plane_segmentation_name,
-    #         )
-    #     )
-    # )
-    # conversion_options.update(
-    #     dict(
-    #         ParcellsSegmentationInterface=dict(
-    #             include_roi_acceptance=False,
-    #             plane_segmentation_name=plane_segmentation_name,
-    #             stub_test=stub_test,
-    #         )
-    #     )
-    # )
+    # Add processed imaging data
+    processed_imaging_path = parcellation_folder_path / "final_dFoF.mat"
+    for excitation_type, channel in excitation_type_channel_combination.items():
+        process_type = excitation_type.lower() if not excitation_type == "Violet" else "uv"
+        suffix = f"{excitation_type}Excitation{channel}Channel"
+        interface_name = f"DFFImaging{suffix}"
+        source_data[interface_name] = {
+            "file_path": processed_imaging_path,
+            "sampling_frequency": sampling_frequency,
+            "photon_series_type": "OnePhotonSeries",
+            "process_type": process_type,
+        }
+        conversion_options[interface_name] = {
+            "stub_test": stub_test,
+            "photon_series_index": photon_series_index,
+            "photon_series_type": "OnePhotonSeries",
+            "parent_container": "processing/ophys",
+        }
+        photon_series_index += 1
+
+    # Add parcellation output data
+    mat_file_path = list(parcellation_folder_path.glob(f"green_{session_id}*.mat"))[0]
+    plane_segmentation_name = "ParcellatedPlaneSegmentation"
+    source_data.update(
+        dict(
+            ParcellsSegmentationInterface=dict(
+                file_path=mat_file_path,
+                sampling_frequency=sampling_frequency,
+                image_size=[256, 256],
+                plane_segmentation_name=plane_segmentation_name,
+            )
+        )
+    )
+    conversion_options.update(
+        dict(
+            ParcellsSegmentationInterface=dict(
+                include_roi_acceptance=False,
+                plane_segmentation_name=plane_segmentation_name,
+                stub_test=stub_test,
+            )
+        )
+    )
     # Add Behavioral Video Recording
     avi_files = list(folder_path.glob(f"{search_pattern}*.avi"))
     video_file_path = avi_files[0]

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
@@ -129,21 +129,21 @@ def session_to_nwb(
         }
         photon_series_index += 1
 
-    # Add Behavioral Video Recording
-    avi_files = list(folder_path.glob(f"{search_pattern}*.avi"))
-    video_file_path = avi_files[0]
-    source_data.update(dict(Video=dict(file_paths=[video_file_path], verbose=False)))
-    conversion_options.update(dict(Video=dict(stub_test=stub_test)))
-
-    # Add Facemap output
-    mat_files = list(folder_path.glob(f"{search_pattern}*_proc.mat"))
-    mat_file_path = mat_files[0]
-    source_data.update(
-        dict(
-            FacemapInterface=dict(mat_file_path=str(mat_file_path), video_file_path=str(video_file_path), verbose=False)
-        )
-    )
-
+    # # Add Behavioral Video Recording
+    # avi_files = list(folder_path.glob(f"{search_pattern}*.avi"))
+    # video_file_path = avi_files[0]
+    # source_data.update(dict(Video=dict(file_paths=[video_file_path], verbose=False)))
+    # conversion_options.update(dict(Video=dict(stub_test=stub_test)))
+    #
+    # # Add Facemap output
+    # mat_files = list(folder_path.glob(f"{search_pattern}*_proc.mat"))
+    # mat_file_path = mat_files[0]
+    # source_data.update(
+    #     dict(
+    #         FacemapInterface=dict(mat_file_path=str(mat_file_path), video_file_path=str(video_file_path), verbose=False)
+    #     )
+    # )
+    #
     ophys_metadata_path = Path(__file__).parent / "metadata" / "lohani_2022_ophys_metadata.yaml"
     ophys_metadata = load_dict_from_file(ophys_metadata_path)
 
@@ -177,7 +177,7 @@ if __name__ == "__main__":
     root_path = Path("E:/CN_data")
     data_dir_path = root_path / "Higley-CN-data-share"
     output_dir_path = root_path / "Higley-conversion_nwb"
-    stub_test = True
+    stub_test = False
     date = "11222019"
     animal_number = "05"
     session_id = f"{date}_grabAM{animal_number}_vis_stim"

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022_convert_session.py
@@ -144,48 +144,48 @@ def session_to_nwb(
         }
         photon_series_index += 1
 
-    # Add processed imaging data
-    processed_imaging_path = parcellation_folder_path / "final_dFoF.mat"
-    for excitation_type, channel in excitation_type_channel_combination.items():
-        process_type = excitation_type.lower() if not excitation_type == "Violet" else "uv"
-        suffix = f"{excitation_type}Excitation{channel}Channel"
-        interface_name = f"DFFImaging{suffix}"
-        source_data[interface_name] = {
-            "file_path": processed_imaging_path,
-            "sampling_frequency": sampling_frequency,
-            "photon_series_type": "OnePhotonSeries",
-            "process_type": process_type,
-        }
-        conversion_options[interface_name] = {
-            "stub_test": stub_test,
-            "photon_series_index": photon_series_index,
-            "photon_series_type": "OnePhotonSeries",
-            "parent_container": "processing/ophys",
-        }
-        photon_series_index += 1
-
-    # Add parcellation output data
-    mat_file_path = list(parcellation_folder_path.glob(f"green_{session_id}*.mat"))[0]
-    plane_segmentation_name = "ParcellatedPlaneSegmentation"
-    source_data.update(
-        dict(
-            ParcellsSegmentationInterface=dict(
-                file_path=mat_file_path,
-                sampling_frequency=sampling_frequency,
-                image_size=[256, 256],
-                plane_segmentation_name=plane_segmentation_name,
-            )
-        )
-    )
-    conversion_options.update(
-        dict(
-            ParcellsSegmentationInterface=dict(
-                include_roi_acceptance=False,
-                plane_segmentation_name=plane_segmentation_name,
-                stub_test=stub_test,
-            )
-        )
-    )
+    # # Add processed imaging data
+    # processed_imaging_path = parcellation_folder_path / "final_dFoF.mat"
+    # for excitation_type, channel in excitation_type_channel_combination.items():
+    #     process_type = excitation_type.lower() if not excitation_type == "Violet" else "uv"
+    #     suffix = f"{excitation_type}Excitation{channel}Channel"
+    #     interface_name = f"DFFImaging{suffix}"
+    #     source_data[interface_name] = {
+    #         "file_path": processed_imaging_path,
+    #         "sampling_frequency": sampling_frequency,
+    #         "photon_series_type": "OnePhotonSeries",
+    #         "process_type": process_type,
+    #     }
+    #     conversion_options[interface_name] = {
+    #         "stub_test": stub_test,
+    #         "photon_series_index": photon_series_index,
+    #         "photon_series_type": "OnePhotonSeries",
+    #         "parent_container": "processing/ophys",
+    #     }
+    #     photon_series_index += 1
+    #
+    # # Add parcellation output data
+    # mat_file_path = list(parcellation_folder_path.glob(f"green_{session_id}*.mat"))[0]
+    # plane_segmentation_name = "ParcellatedPlaneSegmentation"
+    # source_data.update(
+    #     dict(
+    #         ParcellsSegmentationInterface=dict(
+    #             file_path=mat_file_path,
+    #             sampling_frequency=sampling_frequency,
+    #             image_size=[256, 256],
+    #             plane_segmentation_name=plane_segmentation_name,
+    #         )
+    #     )
+    # )
+    # conversion_options.update(
+    #     dict(
+    #         ParcellsSegmentationInterface=dict(
+    #             include_roi_acceptance=False,
+    #             plane_segmentation_name=plane_segmentation_name,
+    #             stub_test=stub_test,
+    #         )
+    #     )
+    # )
     # Add Behavioral Video Recording
     avi_files = list(folder_path.glob(f"{search_pattern}*.avi"))
     video_file_path = avi_files[0]
@@ -240,7 +240,7 @@ if __name__ == "__main__":
     root_path = Path("G:")
     data_dir_path = root_path / "Higley-CN-data-share"
     output_dir_path = root_path / "Higley-conversion_nwb"
-    stub_test = False
+    stub_test = True
     date = "11232019"
     animal_number = "05"
     behavior = "airpuffs"

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022nwbconverter.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022nwbconverter.py
@@ -150,4 +150,4 @@ class Lohani2022NWBConverter(NWBConverter):
 
         if "FacemapInterface" in self.data_interface_objects.keys():
             facemap_interface = self.data_interface_objects["FacemapInterface"]
-            facemap_interface.set_aligned_starting_time(ttl_times[0])
+            facemap_interface.set_aligned_timestamps(video_interface._timestamps[0])  #

--- a/src/higley_lab_to_nwb/lohani_2022/lohani_2022nwbconverter.py
+++ b/src/higley_lab_to_nwb/lohani_2022/lohani_2022nwbconverter.py
@@ -3,13 +3,14 @@
 from typing import Dict, List
 from pynwb import NWBFile
 from neuroconv import NWBConverter
-from neuroconv.datainterfaces import VideoInterface, FacemapInterface, TiffImagingInterface
-from neuroconv.utils import DeepDict
+from neuroconv.datainterfaces import VideoInterface, TiffImagingInterface
+from neuroconv.utils import FilePathType, DeepDict
 from neuroconv.tools.nwb_helpers import make_or_load_nwbfile
 from higley_lab_to_nwb.interfaces import (
     Spike2SignalsInterface,
     VisualStimulusInterface,
     ProcessedImagingInterface,
+    FacemapInterface,
 )
 
 


### PR DESCRIPTION
Add a custom implementation of the Facemap interface in neuroconv to adapt it different file formats:

- [x] **Lohani22 conversion:**  stub file [here](https://catalystneuro-processing.s3.us-east-2.amazonaws.com/higley-lab-to-nwb/11232019_grabAM05_airpuffs_facemap.nwb)
- newer matlab version
- output structure as in https://github.com/catalystneuro/neuroconv/pull/752#issuecomment-1951456297

- [x]  **Benisty24 conversion (2p-only):** stub file [here](https://catalystneuro-processing.s3.us-east-2.amazonaws.com/higley-lab-to-nwb/04072021_am2psi_05_spont_facemap.nwb)
- older matlab version
- output structure as in https://github.com/catalystneuro/neuroconv/pull/752#issuecomment-1951456297

- [x]  **Benisty24 conversion (dual config):**  stub file [here](https://catalystneuro-processing.s3.us-east-2.amazonaws.com/higley-lab-to-nwb/20201231_00001_dbvdual035_facemap.nwb)
- some sessions have older matlab version some session have newer matlab version
- some sessions have a different output structure: 
  - **filenames**: list of lists of video filenames - each list are the videos taken simultaneously
  - **Ly**, **Lx**: list of number of pixels in Y (Ly) and X (Lx) for each video taken simultaneously
  - **sbin**: spatial bin size for motion SVDs
  - **Lybin**, **Lxbin**: list of number of pixels binned by sbin in Y (Ly) and X (Lx) for each video taken simultaneously
  - **sybin**, **sxbin**: coordinates of multivideo (for plotting/reshaping ONLY)
  - **LYbin**, **LXbin**: full-size of all videos embedded in rectangle (binned)
  - **fullSVD**: whether or not "multivideo SVD" is computed
  - **save_mat**: whether or not to save proc as *.mat file
  - **avgframe**: list of average frames for each video from a subset of frames (binned by sbin)
  - **avgframe_reshape**: average frame reshaped to be y-pixels x x-pixels
  - **avgmotion**: list of average motions for each video from a subset of frames (binned by sbin)
  - **avgmotion_reshape**: average motion reshaped to be y-pixels x x-pixels
  - **motion**: list of absolute motion energies across time - first is "multivideo" motion energy (empty if not computed)
  - **motSVD**: list of motion SVDs - first is "multivideo SVD" (empty if not computed) - each is nframes x components
  - **motMask**: list of motion masks for each motion SVD - each motMask is pixels x components
  - **motMask_reshape**: motion masks reshaped to be y-pixels x x-pixels x components
  - **pupil**: list of pupil ROI outputs - each is a dict with 'area', 'area_smooth', and 'com' (center-of-mass)
  - **blink**: list of blink ROI outputs - each is nframes, the blink area on each frame
  - **running**: list of running ROI outputs - each is nframes x 2, for X and Y motion on each frame
  - **rois**: ROIs that were drawn and computed
      - *rind*: type of ROI in number
      - *rtype*: what type of ROI ('motion SVD', 'pupil', 'blink', 'running')
      - *ivid*: in which video is the ROI
      - *color*: color of ROI
      - *yrange*: y indices of ROI
      - *xrange*: x indices of ROI
      - *saturation*: saturation of ROI (0-255)
      - *pupil_sigma*: number of stddevs used to compute pupil radius (for pupil ROIs)
      - *yrange_bin*: binned indices in y (if motion SVD)
      - *xrange_bin*: binned indices in x (if motion SVD)